### PR TITLE
Changed rules 1002 according to issue 33

### DIFF
--- a/config/rules/password-secret.yaml
+++ b/config/rules/password-secret.yaml
@@ -16,7 +16,7 @@
 Searcharea: body
 rules:
   - Code: 1002
-    Pattern: (?i)"p[a4@][s$][s$]w[o0]rd([#!@]?(123)?)?"
+    Pattern: (?i)"*p[a4@][s$][s$]w[o0]rd([#!@]?(123)?)?"
     Caption: Potential default password in file
     Category: password-secret
     Example: '"password"'


### PR DESCRIPTION
This allow to cover Password which doesn't start immediately with the P as the MyPassw0rd example.