### PR TITLE
fix(config): updated config based display and failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,42 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
-	golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 // indirect
-	golang.org/x/text v0.3.2
+	golang.org/x/text v0.7.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
+)
+
+require (
+	github.com/JalfResi/justext v0.0.0-20170829062021-c0282dea7198 // indirect
+	github.com/PuerkitoBio/goquery v1.5.1 // indirect
+	github.com/advancedlogic/GoOse v0.0.0-20191112112754-e742535969c1 // indirect
+	github.com/andybalholm/cascadia v1.2.0 // indirect
+	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/set v0.2.1 // indirect
+	github.com/gigawattio/window v0.0.0-20180317192513-0f5467e35573 // indirect
+	github.com/go-resty/resty/v2 v2.3.0 // indirect
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
+	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.4 // indirect
+	github.com/otiai10/gosseract/v2 v2.2.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/richardlehane/mscfb v1.0.3 // indirect
+	github.com/richardlehane/msoleps v1.0.1 // indirect
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 // indirect
+	google.golang.org/protobuf v1.23.0 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 h1:qSa+Hg9oBe6UJXrznE+yYvW51
 golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/postprocess/validatePassword.go
+++ b/pkg/postprocess/validatePassword.go
@@ -85,8 +85,8 @@ func PasswordFalse(password string) (confidence int, ignore bool) {
 		if strings.Contains(password, "(") && strings.Contains(password, ")") {
 			return confidence, true
 		}
-		confidence = 2 // Mark confidence high if passes all the following
 	}
+	confidence = 2 // Mark confidence high if passes all the following
 
 	return confidence, false
 }
@@ -119,6 +119,7 @@ func SkipPasswordWithUnicode(password string) bool {
 	}
 	return false
 }
+
 // SkipPasswordWithHTMLEntities returns true if the password value contains a HTML entities.
 // UseCase: Html entities are used as contents in localized files. ex - "L&#246;senord" is "Lösenord"
 func SkipPasswordWithHTMLEntities(password string) bool {
@@ -128,7 +129,7 @@ func SkipPasswordWithHTMLEntities(password string) bool {
 		// Unescape the html entities into string to compare with original password value
 		passwordStringValue := html.UnescapeString(strings.TrimSpace(passwords[1]))
 		// ex - "L&#246;senord" is "Lösenord" if after html.UnescapeString they are not equal then it has html entities.
-		if passwordStringValue != strings.TrimSpace(passwords[1]){
+		if passwordStringValue != strings.TrimSpace(passwords[1]) {
 			return true
 		}
 	}

--- a/pkg/postprocess/validatePassword_test.go
+++ b/pkg/postprocess/validatePassword_test.go
@@ -121,7 +121,7 @@ var tests = []struct {
 		args: args{
 			testPD: "\"my.property\": \"sample%3YmlPassword\"",
 		},
-		wantConfidence: 3,
+		wantConfidence: 2,
 		wantIgnore:     false,
 	},
 }
@@ -199,6 +199,7 @@ func TestSkipUnicodeInPasswords(t *testing.T) {
 		})
 	}
 }
+
 var testSkipHTMLEntitiesInPasswords = []struct {
 	name       string
 	args       args
@@ -251,4 +252,3 @@ func TestSkipHTMLEntitiesInPasswords(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -103,9 +103,14 @@ func scanPool(cfg *cfgReader.EarlybirdConfig, wg *sync.WaitGroup, jobMutex *sync
 							continue
 						}
 						jobMutex.Unlock()
-						hits <- hit //Push hits to channel
 
-						cfg.FailScan = determineScanFail(cfg, &hit)
+						if hit.ConfidenceID <= cfg.ConfidenceDisplayLevel {
+							hits <- hit //Push hits to channel
+						}
+
+						if !cfg.FailScan {
+							cfg.FailScan = determineScanFail(cfg, &hit)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This is fixing https://github.com/americanexpress/earlybird/issues/54.

As part of the change,

- I have added a check for failScan flag and calling determine fail scan only if needed.
- Also checking for --display-confidence flag while creating hits since post processor is changing confidence level.