### PR TITLE
chore(workflows): use the latest major versions of actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     outputs:
       earlybird_next_version: ${{ steps.getversion.outputs.earlybird_next_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get version for next release
@@ -29,15 +29,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.18
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build project
         run: ./build.sh ${{ needs.get_next_version.outputs.earlybird_next_version }}
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: earlybird-binaries
           path: ./binaries/
@@ -49,11 +49,11 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN}}
       - name: Download earlybird artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Copy artifacts to current directory
         run: mv earlybird-binaries/* .
       - name: Print current directory
@@ -63,7 +63,7 @@ jobs:
       - name: Rename arm64 macOS binary
         run: mv go-earlybird-arm64 go-earlybird-arm64-macos
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Create a release with Semantic Release

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.18
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: ./build.sh


### PR DESCRIPTION
avoid warning annotations, e.g. from https://github.com/americanexpress/earlybird/actions/runs/6238642518:
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

My assessment is none of the breaking changes are in use by this repository's workflows
- https://github.com/actions/setup-node/releases/tag/v3.0.0
- https://github.com/actions/checkout/releases/tag/v3.0.0
- https://github.com/actions/setup-go/releases/tag/v3.0.0
- https://github.com/actions/setup-go/releases/tag/v4.0.0
- https://github.com/actions/upload-artifact/releases/tag/v3.0.0
- https://github.com/actions/download-artifact/releases/tag/v3.0.0