### PR TITLE
feat(config): added config to avoid exit code 1 for scan failure

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -75,6 +75,8 @@ Usage of go-earlybird:
     	Certificate file for TLS
   -https-key string
     	Private key file for TLS
+  -ignore-failure
+        Avoid the exit code 1 in case of scanner finds valid findings and meets fail threshold
   -ignore-fp-rules
     	Ignore the false positive post-process rules
   -ignorefile string

--- a/pkg/config/structures.go
+++ b/pkg/config/structures.go
@@ -18,7 +18,7 @@ package cfgreader
 
 import "regexp"
 
-//ServerConfig is the timeout configuration for the Earlybird REST API server
+// ServerConfig is the timeout configuration for the Earlybird REST API server
 type ServerConfig struct {
 	WriteTimeout int `json:"write-timeout"`
 	ReadTimeout  int `json:"read-timeout"`
@@ -37,7 +37,7 @@ type AdjustedSeverityCategory struct {
 	// If UseFileName and UseLine value are either both false or undefined the match defaults to hit.MatchValue
 }
 
-//Configs is the result of earlybird.json
+// Configs is the result of earlybird.json
 type Configs struct {
 	LevelConfigs []struct {
 		Name string `json:"level_name"`
@@ -66,7 +66,7 @@ type ModuleConfigs struct {
 	Modules map[string]ModuleConfig `json:"modules"`
 }
 
-//EarlybirdConfig is the overall scan configs from config file and cli params
+// EarlybirdConfig is the overall scan configs from config file and cli params
 type EarlybirdConfig struct {
 	AvailableModules           []string
 	RuleModulesFilenameMap     map[string]string
@@ -79,6 +79,7 @@ type EarlybirdConfig struct {
 	OutputFormat               string
 	OutputFile                 string
 	IgnoreFile                 string
+	IgnoreFailure              bool
 	SeverityFailLevel          int
 	SeverityDisplayLevel       int
 	ConfidenceFailLevel        int

--- a/pkg/core/const.go
+++ b/pkg/core/const.go
@@ -68,6 +68,7 @@ var (
 	ptrWithConsole                = flag.Bool("with-console", false, "While using --format, this flag will help to print findings in console")
 	ptrOutputFile                 = flag.String("file", "", "Output file -- e.g., 'go-earlybird --file=/home/jdoe/myfile.csv'")
 	ptrIgnoreFile                 = flag.String("ignorefile", userHomeDir+string(os.PathSeparator)+".ge_ignore", "Patterns File (including wildcards) for files to ignore.  (e.g. *.jpg)")
+	ptrIgnoreFailure              = flag.Bool("ignore-failure", false, "Avoid the exit code 1 in case of scanner finds valid findings and meets fail threshold")
 	ptrFailSeverityThreshold      = flag.String("fail-severity", cfgreader.Settings.TranslateLevelID(cfgreader.Settings.FailThreshold), "Lowest severity level at which to fail "+levelOptions)
 	ptrDisplaySeverityThreshold   = flag.String("display-severity", cfgreader.Settings.TranslateLevelID(cfgreader.Settings.DisplayThreshold), "Lowest severity level to display "+levelOptions)
 	ptrDisplayConfidenceThreshold = flag.String("display-confidence", cfgreader.Settings.TranslateLevelID(cfgreader.Settings.DisplayConfidenceThreshold), "Lowest confidence level to display "+levelOptions)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -45,7 +45,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-//GitClone clones git repositories into a temporary directory
+// GitClone clones git repositories into a temporary directory
 func (eb *EarlybirdCfg) GitClone(ptr PTRGitConfig) {
 	var scanRepos []string
 	gitPassword := os.Getenv("gitpassword")
@@ -90,7 +90,7 @@ func (eb *EarlybirdCfg) GitClone(ptr PTRGitConfig) {
 	}
 }
 
-//StartHTTP spins up the Earlybird REST API server
+// StartHTTP spins up the Earlybird REST API server
 func (eb *EarlybirdCfg) StartHTTP(ptr PTRHTTPConfig) {
 	// Set up http server
 	r := mux.NewRouter()
@@ -166,7 +166,7 @@ func (eb *EarlybirdCfg) GetRuleModulesMap() (err error) {
 	return err
 }
 
-//ConfigInit loads in the earlybird configuration and CLI flags
+// ConfigInit loads in the earlybird configuration and CLI flags
 func (eb *EarlybirdCfg) ConfigInit() {
 	// Set the version from ldflags
 	eb.Config.Version = buildflags.Version
@@ -200,6 +200,7 @@ func (eb *EarlybirdCfg) ConfigInit() {
 	eb.Config.OutputFile = *ptrOutputFile
 	eb.Config.SearchDir = *ptrPath
 	eb.Config.IgnoreFile = *ptrIgnoreFile
+	eb.Config.IgnoreFailure = *ptrIgnoreFailure
 	eb.Config.GitStream = *ptrGitStreamInput
 	eb.Config.RulesOnly = *ptrRulesOnly
 	eb.Config.SkipComments = *ptrSkipComments
@@ -282,7 +283,7 @@ func (eb *EarlybirdCfg) getDefaultModuleSettings() {
 	}
 }
 
-//Scan Runs the scan by kicking off the different modules as go routines
+// Scan Runs the scan by kicking off the different modules as go routines
 func (eb *EarlybirdCfg) Scan() {
 	// Validate the path passed in as the target directory to scan
 	start := time.Now()
@@ -301,11 +302,13 @@ func (eb *EarlybirdCfg) Scan() {
 		if eb.Config.OutputFormat == "console" {
 			fmt.Fprintln(os.Stderr, "Scan detected findings above the accepted threshold -- Failing.")
 		}
-		os.Exit(1)
+		if !eb.Config.IgnoreFailure {
+			os.Exit(1)
+		}
 	}
 }
 
-//FileContext provides an inclusive file system context of our scan
+// FileContext provides an inclusive file system context of our scan
 func (eb *EarlybirdCfg) FileContext() (fileContext file.Context, err error) {
 	cfg := eb.Config
 	if cfg.SearchDir != "" {
@@ -330,7 +333,7 @@ func (eb *EarlybirdCfg) FileContext() (fileContext file.Context, err error) {
 	return fileContext, nil
 }
 
-//WriteResults reads hits from the channel to the console or target file
+// WriteResults reads hits from the channel to the console or target file
 func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, fileContext file.Context) {
 	// Send output to a writer
 	var err error


### PR DESCRIPTION
This PR is addressing issue https://github.com/americanexpress/earlybird/issues/101 which talks about having difficulty to exit the process with status code `exit : 0`.  As part of these changes, I have added `-ignore-failure` configuration and set the default value to `false`. Meaning this is non breaking change and provide user a way to configure the final exit status upon scan completion.


-------------------------------------------------------------------


Usage Example:
 ```
go run go-earlybird.go --path=/Users/hero/repo1 --fail-severity low --ignore-failure=true
```
Output
```
Finding # 1:
        Code #: 4059
        Filename: /Users/hero/repo1/temp/src/test/resources/secrets/sample.jks
        Caption: Java keystore file
        Category: key
        Line #: 0
        Value: sample.jks
        Severity: medium
        Confidence: high
        Labels: None
        Associated CWEs: CWE-312/CWE-321

        ***** Total issues found *****
            1 Java keystore file
            1 TOTAL ISSUES
2024/02/06 07:43:15 
303 files scanned in 483.806286ms
2024/02/06 07:43:15 
114 rules observed
Scan detected findings above the accepted threshold -- Failing.
```