### PR TITLE
fix: require digits for card mod10 check

### DIFF
--- a/pkg/postprocess/luhn.go
+++ b/pkg/postprocess/luhn.go
@@ -28,6 +28,9 @@ var (
 //IsCard Run a mod10 check on a potential card number
 func IsCard(cc string) bool {
 	cc = isolateNumber(cc)
+	if len(cc) == 0 {
+		return false
+	}
 	checksum := 0
 	bOdd := false
 	card := []byte(cc)

--- a/pkg/postprocess/luhn_test.go
+++ b/pkg/postprocess/luhn_test.go
@@ -53,6 +53,11 @@ func TestIsCard(t *testing.T) {
 			"100000000000000",
 			false,
 		},
+		{
+			"No digits in value - not a card number",
+			"ABCDEFG",
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A string with no digits should not be identified as a card number via the mod10 check even though it trivially passes the test due to having a checksum value of 0.