### PR TITLE
fix(ssn): updated ssn rule to ignore flaging 9xx in third group

### DIFF
--- a/pkg/postprocess/validateSSN.go
+++ b/pkg/postprocess/validateSSN.go
@@ -28,7 +28,7 @@ func ValidSSN(ssn string) bool {
 	if len(groups) != 3 {
 		return false
 	}
-	if first, _ := strconv.Atoi(groups[0]); first == 666 || first <= 0 || first > 999 {
+	if first, _ := strconv.Atoi(groups[0]); first == 666 || first <= 0 || first > 900 {
 		return false
 	} else if second, _ := strconv.Atoi(groups[1]); second <= 0 || second > 99 {
 		return false

--- a/pkg/postprocess/validateSSN_test.go
+++ b/pkg/postprocess/validateSSN_test.go
@@ -47,6 +47,16 @@ func TestValidSSN(t *testing.T) {
 			ssn:  "666-000-0000",
 			want: false,
 		},
+		{
+			name: "Test invalid SSN",
+			ssn:  "900-000-0000",
+			want: false,
+		},
+		{
+			name: "Test invalid SSN",
+			ssn:  "999-000-0000",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Added check for first group number > 900. This will fix https://github.com/americanexpress/earlybird/issues/110