### PR TITLE
feat(jks-check): added config to strictly check for key in jks

### DIFF
--- a/config/rules/filename.yaml
+++ b/config/rules/filename.yaml
@@ -673,7 +673,7 @@ rules:
     SolutionID: 11
     Severity: 2
     Confidence: 2
-    Postprocess: ''
+    Postprocess: jks
     CWE:
       - CWE-312
       - CWE-321

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -93,6 +93,8 @@ Usage of go-earlybird:
     	Skip scanning comments in files -- applies only to the 'content' module
   -stream
     	Use stream IO as input instead of file(s)
+  -strict-jks
+        Checks for private keys in the JKS file and only return finding if found. If not passed, it will flag jks file. Default is false.
   -suppress
     	Suppress reporting of the secret found (important if output is going to Slack or other logs)
   -update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/americanexpress/earlybird/v4
 
-go 1.23
+go 1.23.5
 
 require (
 	code.sajari.com/docconv v1.3.8

--- a/pkg/config/structures.go
+++ b/pkg/config/structures.go
@@ -106,6 +106,7 @@ type EarlybirdConfig struct {
 	WorkerCount                int
 	WorkLength                 int
 	HideMeta                   bool
+	StrictJKS                  bool
 	ModuleConfigs              ModuleConfigs
 	AdjustedSeverityCategories []AdjustedSeverityCategory
 }

--- a/pkg/core/const.go
+++ b/pkg/core/const.go
@@ -52,7 +52,7 @@ var (
 	ptrGitStreamInput             = flag.Bool("git-commit-stream", false, "Use stream IO of Git commit log as input instead of file(s) -- e.g., 'cat secrets.text > go-earlybird'")
 	ptrVerbose                    = flag.Bool("verbose", false, "Reports details about file reads")
 	ptrSuppressSecret             = flag.Bool("suppress", false, "Suppress reporting of the secret found (important if output is going to Slack or other logs)")
-	ptrStrictJKS = flag.Bool("strict-jks", false, "Checks for private keys in the JKS file and return hits only if found")
+	ptrStrictJKS                  = flag.Bool("strict-jks", false, "Checks for private keys in the JKS file and return hits only if found")
 	ptrWorkerCount                = flag.Int("workers", 100, "Set number of workers.")
 	ptrWorkLength                 = flag.Int("worksize", 2500, "Set Line Wrap Length.")
 	ptrMaxFileSize                = flag.Int64("max-file-size", 10240000, "Maximum file size to scan (in bytes)")

--- a/pkg/core/const.go
+++ b/pkg/core/const.go
@@ -52,6 +52,7 @@ var (
 	ptrGitStreamInput             = flag.Bool("git-commit-stream", false, "Use stream IO of Git commit log as input instead of file(s) -- e.g., 'cat secrets.text > go-earlybird'")
 	ptrVerbose                    = flag.Bool("verbose", false, "Reports details about file reads")
 	ptrSuppressSecret             = flag.Bool("suppress", false, "Suppress reporting of the secret found (important if output is going to Slack or other logs)")
+	ptrStrictJKS = flag.Bool("strict-jks", false, "Checks for private keys in the JKS file and return hits only if found")
 	ptrWorkerCount                = flag.Int("workers", 100, "Set number of workers.")
 	ptrWorkLength                 = flag.Int("worksize", 2500, "Set Line Wrap Length.")
 	ptrMaxFileSize                = flag.Int64("max-file-size", 10240000, "Maximum file size to scan (in bytes)")

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -195,6 +195,7 @@ func (eb *EarlybirdCfg) ConfigInit() {
 	eb.Config.MaxFileSize = *ptrMaxFileSize
 	eb.Config.VerboseEnabled = *ptrVerbose
 	eb.Config.Suppress = *ptrSuppressSecret
+	eb.Config.StrictJKS = *ptrStrictJKS
 	eb.Config.OutputFormat = *ptrOutputFormat
 	eb.Config.WithConsole = *ptrWithConsole
 	eb.Config.OutputFile = *ptrOutputFile

--- a/pkg/jks/jks.go
+++ b/pkg/jks/jks.go
@@ -1,0 +1,160 @@
+/*
+Package jks provides routines for manipulating Java Keystore files.
+*/
+package jks
+
+import (
+	"crypto/sha1"
+	"crypto/x509"
+	"time"
+	"unicode/utf16"
+)
+
+const (
+	// MagicNumber is written at the start of each .jks file.
+	MagicNumber uint32 = 0xFEEDFEED
+
+	// DigestSeparator is used to build the file's verification digest. The
+	// digest is over the keystore password encoded as UTF-16, then this
+	// string (yes, really — check the OpenJDK source) encoded as UTF-8, and
+	// then the actual file data.
+	DigestSeparator = "Mighty Aphrodite"
+
+	// CertType is the certificate type string that is encoded into each
+	// certificate's header in the keystore.
+	CertType = "X.509"
+)
+
+// Keystore represents a single JKS file. It holds a list of certificates and a
+// list of keypairs (private keys with associated certificate chains).
+type Keystore struct {
+	// Certs is a list of CA certificates to trust. It may contain either
+	// root or intermediate CA certificates. It should not contain end-user
+	// certificates.
+	Certs []*Cert
+
+	// Keypairs is a list of private keys. Each key may have a certificate
+	// chain associated with it.
+	Keypairs []*Keypair
+}
+
+// Options for manipulating a keystore. These allow the caller to specify the
+// password(s) used, or to skip the digest verification if the password is
+// unknown.
+type Options struct {
+	// Password is used as part of a SHA-1 digest over the .jks file.
+	Password string
+
+	// SkipVerifyDigest can be set to skip digest verification when loading
+	// a keystore file. This will inhibit errors from Parse if you don't
+	// know the password.
+	SkipVerifyDigest bool
+
+	// KeyPasswords are used to generate the "encryption" keys for stored
+	// private keys. The map's key is the alias of the private key, and the
+	// value is the password. If there is no entry in the map for a given
+	// alias, then the top-level Password is inherited. Empty strings are
+	// interpreted as an empty password, so use delete() if you truly want
+	// to delete values.
+	KeyPasswords map[string]string
+}
+
+// Cert holds a certificate to trust.
+type Cert struct {
+	// Alias is a name used to refer to this certificate.
+	Alias string
+
+	// Timestamp records when this record was created.
+	Timestamp time.Time
+
+	// Raw is the raw X.509 certificate marshalled in DER form.
+	Raw []byte
+
+	// CertErr is set if there is an error parsing the certificate.
+	CertErr error
+
+	// Cert is the parsed X.509 certificate.
+	Cert *x509.Certificate
+}
+
+// Keypair holds a private key and an associated certificate chain.
+type Keypair struct {
+	// Alias is a name used to refer to this keypair.
+	Alias string
+
+	// Timestamp records when this record was created.
+	Timestamp time.Time
+
+	// PrivKeyErr is set if an error is encountered during decryption or
+	// unmarshalling of the decrypted key.
+	PrivKeyErr error
+
+	// EncryptedKey is the raw PKCS#8 marshalled EncryptedPrivateKeyInfo.
+	EncryptedKey []byte
+
+	// RawKey is the raw PKCS#8 marshalled PrivateKeyInfo, after it has
+	// been decrypted. It will not have been set if decryption failed.
+	RawKey []byte
+
+	// PrivateKey is the unmarshalled private key. It will not have been
+	// set if decryption failed or if unmarshalling failed.
+	PrivateKey interface{}
+
+	// CertChain is a chain of certificates associated with the private key.
+	// The first entry in the chain (index 0) should correspond to
+	// PrivateKey; there should then follow any intermediate CAs. In
+	// general the root CA should not be part of the chain.
+	CertChain []*KeypairCert
+}
+
+// KeypairCert is an entry in the certificate chain associated with a Keypair.
+type KeypairCert struct {
+	// Raw X.509 certificate data (in DER form).
+	Raw []byte
+
+	// Cert is the parsed X.509 certificate. It is nil if the certificate
+	// could not be parsed.
+	Cert *x509.Certificate
+
+	// CertErr records any error encountered while parsing a certificate.
+	CertErr error
+}
+
+var defaultOptions = Options{
+	SkipVerifyDigest: true,
+}
+
+// ComputeDigest performs the custom hash function over the given file data.
+// DO NOT RE-USE THIS CODE: this is an atrocious way to perform message
+// authentication. Use the HMAC example from
+// https://github.com/lwithers/go-crypto-examples instead. Note this construct
+// is vulnerable to a length extension attack, which is actually exploitable if
+// the JKS reader code does not properly check the "number of entries" value.
+func ComputeDigest(raw []byte, passwd string) []byte {
+	// compute SHA-1 digest over the construct:
+	//  UTF-16(password) + UTF-8(DigestSeparator) + raw
+	md := sha1.New()
+	p := PasswordUTF16(passwd)
+	md.Write(p)
+	md.Write([]byte(DigestSeparator))
+	md.Write(raw)
+	return md.Sum(nil)
+}
+
+// PasswordUTF16 returns a password encoded in UTF-16, big-endian byte order.
+func PasswordUTF16(passwd string) []byte {
+	var u []byte
+	for _, r := range passwd {
+		if r < 0x10000 {
+			u = append(u, byte((r>>8)&0xFF))
+			u = append(u, byte(r&0xFF))
+		} else {
+			r1, r2 := utf16.EncodeRune(r)
+			u = append(u, byte((r1>>8)&0xFF))
+			u = append(u, byte(r1&0xFF))
+			u = append(u, byte((r2>>8)&0xFF))
+			u = append(u, byte(r2&0xFF))
+		}
+	}
+	return u
+}

--- a/pkg/jks/jks.go
+++ b/pkg/jks/jks.go
@@ -4,7 +4,6 @@ Package jks provides routines for manipulating Java Keystore files.
 package jks
 
 import (
-	"crypto/sha1"
 	"crypto/x509"
 	"time"
 	"unicode/utf16"
@@ -36,27 +35,6 @@ type Keystore struct {
 	// Keypairs is a list of private keys. Each key may have a certificate
 	// chain associated with it.
 	Keypairs []*Keypair
-}
-
-// Options for manipulating a keystore. These allow the caller to specify the
-// password(s) used, or to skip the digest verification if the password is
-// unknown.
-type Options struct {
-	// Password is used as part of a SHA-1 digest over the .jks file.
-	Password string
-
-	// SkipVerifyDigest can be set to skip digest verification when loading
-	// a keystore file. This will inhibit errors from Parse if you don't
-	// know the password.
-	SkipVerifyDigest bool
-
-	// KeyPasswords are used to generate the "encryption" keys for stored
-	// private keys. The map's key is the alias of the private key, and the
-	// value is the password. If there is no entry in the map for a given
-	// alias, then the top-level Password is inherited. Empty strings are
-	// interpreted as an empty password, so use delete() if you truly want
-	// to delete values.
-	KeyPasswords map[string]string
 }
 
 // Cert holds a certificate to trust.
@@ -118,27 +96,6 @@ type KeypairCert struct {
 
 	// CertErr records any error encountered while parsing a certificate.
 	CertErr error
-}
-
-var defaultOptions = Options{
-	SkipVerifyDigest: true,
-}
-
-// ComputeDigest performs the custom hash function over the given file data.
-// DO NOT RE-USE THIS CODE: this is an atrocious way to perform message
-// authentication. Use the HMAC example from
-// https://github.com/lwithers/go-crypto-examples instead. Note this construct
-// is vulnerable to a length extension attack, which is actually exploitable if
-// the JKS reader code does not properly check the "number of entries" value.
-func ComputeDigest(raw []byte, passwd string) []byte {
-	// compute SHA-1 digest over the construct:
-	//  UTF-16(password) + UTF-8(DigestSeparator) + raw
-	md := sha1.New()
-	p := PasswordUTF16(passwd)
-	md.Write(p)
-	md.Write([]byte(DigestSeparator))
-	md.Write(raw)
-	return md.Sum(nil)
 }
 
 // PasswordUTF16 returns a password encoded in UTF-16, big-endian byte order.

--- a/pkg/jks/jks_test.go
+++ b/pkg/jks/jks_test.go
@@ -1,0 +1,70 @@
+package jks
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+	"unicode/utf16"
+)
+
+// TestComputeDigest is a regression test for the digest function.
+func TestComputeDigest(t *testing.T) {
+	t.Run("empty", testComputeDigest("", "",
+		"569D05A766C473698C0B58EBAEAE0A25EB10BACC"))
+	t.Run("regr", testComputeDigest("input data", "password",
+		"74DDD13B68919674D4409A19AB284019A1DA57C8"))
+}
+
+func testComputeDigest(in, passwd, expHex string) func(*testing.T) {
+	return func(t *testing.T) {
+		exp, err := hex.DecodeString(expHex)
+		if err != nil {
+			t.Fatalf("error decoding expHex: %v", err)
+		}
+		out := ComputeDigest([]byte(in), passwd)
+		if !bytes.Equal(out, exp) {
+			t.Errorf("output sequence (len %d) ≠ expected",
+				len(out))
+			t.Errorf("out %X", out)
+		}
+	}
+}
+
+// TestPasswordUTF16 checks that our UTF-16 encoding routine works as expected.
+// The test cases incorporate empty strings and Unicode strings with characters
+// outside the BMP (basic multilingual plane), i.e. ones that need encoding as
+// UTF-16 surrogate pairs.
+func TestPasswordUTF16(t *testing.T) {
+	t.Run("empty", testPasswordBytes("", nil))
+	t.Run("ascii-1", testPasswordBytes("ascii",
+		[]byte{0, 'a', 0, 's', 0, 'c', 0, 'i', 0, 'i'}))
+	t.Run("ascii-2", testPasswordUTF16("ascii"))
+	t.Run("utf8", testPasswordUTF16("a≤b"))
+	t.Run("surrogate", testPasswordUTF16("z1\U00016000\u2340•—@.µ"))
+}
+
+func testPasswordBytes(in string, exp []byte) func(*testing.T) {
+	return func(t *testing.T) {
+		out := PasswordUTF16(in)
+		if !bytes.Equal(out, exp) {
+			t.Errorf("output sequence ‘%X’ ≠ expected ‘%X’",
+				out, exp)
+		}
+	}
+}
+
+func testPasswordUTF16(in string) func(*testing.T) {
+	return func(t *testing.T) {
+		out := PasswordUTF16(in)
+		expStr := utf16.Encode([]rune(in))
+		exp := make([]byte, len(expStr)*2)
+		for i, v := range expStr {
+			binary.BigEndian.PutUint16(exp[i*2:], v)
+		}
+		if !bytes.Equal(out, exp) {
+			t.Errorf("output sequence ‘%X’ ≠ expected ‘%X’",
+				out, exp)
+		}
+	}
+}

--- a/pkg/jks/jks_test.go
+++ b/pkg/jks/jks_test.go
@@ -3,33 +3,9 @@ package jks
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"testing"
 	"unicode/utf16"
 )
-
-// TestComputeDigest is a regression test for the digest function.
-func TestComputeDigest(t *testing.T) {
-	t.Run("empty", testComputeDigest("", "",
-		"569D05A766C473698C0B58EBAEAE0A25EB10BACC"))
-	t.Run("regr", testComputeDigest("input data", "password",
-		"74DDD13B68919674D4409A19AB284019A1DA57C8"))
-}
-
-func testComputeDigest(in, passwd, expHex string) func(*testing.T) {
-	return func(t *testing.T) {
-		exp, err := hex.DecodeString(expHex)
-		if err != nil {
-			t.Fatalf("error decoding expHex: %v", err)
-		}
-		out := ComputeDigest([]byte(in), passwd)
-		if !bytes.Equal(out, exp) {
-			t.Errorf("output sequence (len %d) ≠ expected",
-				len(out))
-			t.Errorf("out %X", out)
-		}
-	}
-}
 
 // TestPasswordUTF16 checks that our UTF-16 encoding routine works as expected.
 // The test cases incorporate empty strings and Unicode strings with characters

--- a/pkg/jks/pkcs8.go
+++ b/pkg/jks/pkcs8.go
@@ -1,0 +1,280 @@
+package jks
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+)
+
+var (
+	// JavaKeyEncryptionOID1 is the object identifier for one type of
+	// password-based encryption used in .jks files.
+	JavaKeyEncryptionOID1 = asn1.ObjectIdentifier{
+		1, 3, 6, 1, 4, 1, 42, 2, 17, 1, 1,
+	}
+
+	// JavaKeyEncryptionOID2 is the object identifier for one type of
+	// password-based encryption used in .jks files.
+	JavaKeyEncryptionOID2 = asn1.ObjectIdentifier{
+		1, 3, 6, 1, 4, 1, 42, 2, 19, 1,
+	}
+
+	// RFC 3279 § 2.3
+	oidPublicKeyRSA = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
+
+	// RFC 5480 § 2.1.1
+	oidPublicKeyECDSA = asn1.ObjectIdentifier{1, 2, 840, 10045, 2, 1}
+	oidNamedCurveP224 = asn1.ObjectIdentifier{1, 3, 132, 0, 33}
+	oidNamedCurveP256 = asn1.ObjectIdentifier{1, 2, 840, 10045, 3, 1, 7}
+	oidNamedCurveP384 = asn1.ObjectIdentifier{1, 3, 132, 0, 34}
+	oidNamedCurveP521 = asn1.ObjectIdentifier{1, 3, 132, 0, 35}
+
+	// Java appears to want unused parameters structures encoded as an
+	// ASN.1 NULL type.
+	asn1NULL = asn1.RawValue{
+		FullBytes: []byte{0x05, 0x00},
+	}
+)
+
+// EncryptedPrivateKeyInfo is the ASN.1 structure used to hold an encrypted
+// private key. It is defined in RFC 5208 § 6:
+//  https://tools.ietf.org/html/rfc5208#section-6
+type EncryptedPrivateKeyInfo struct {
+	// Algo identifies the encryption algorithm (and any associated
+	// parameters) used to encrypt EncryptedData.
+	Algo pkix.AlgorithmIdentifier
+
+	// EncryptedData is an encrypted, marshalled PrivateKeyInfo.
+	EncryptedData []byte
+}
+
+// PrivateKeyInfo is the ASN.1 structure used to hold a private key. It is
+// defined in RFC 52080 § 5:
+//  https://tools.ietf.org/html/rfc5208#section-5
+type PrivateKeyInfo struct {
+	// Version of structure. Should be zero.
+	Version int
+
+	// Algo denotes the private key algorithm (e.g. RSA).
+	Algo pkix.AlgorithmIdentifier
+
+	// PrivateKey is the marshalled private key. It should be interpreted
+	// according to Algo.
+	PrivateKey []byte
+}
+
+// DecryptPKCS8 decrypts a PKCS#8 EncryptedPrivateKeyInfo, presumably returning
+// a marshalled PrivateKeyInfo structure. It only knows how to handle the two
+// encryption algorithms that are used by the Java keytool program.
+func DecryptPKCS8(raw []byte, password string) ([]byte, error) {
+	// unmarshal the ASN.1 structure, ensure there's no trailing data
+	var keyInfo EncryptedPrivateKeyInfo
+	rest, err := asn1.Unmarshal(raw, &keyInfo)
+	if err != nil {
+		// asn1 package errors are not actually that helpful
+		return nil, errors.New("malformed PKCS#8 private key structure")
+	}
+	if len(rest) != 0 {
+		return nil, errors.New("trailing data after PKCS#8 private key")
+	}
+
+	switch {
+	case keyInfo.Algo.Algorithm.Equal(JavaKeyEncryptionOID1):
+		// this algorithm doesn't have any parameters
+		if len(keyInfo.Algo.Parameters.Bytes) != 0 {
+			return nil, errors.New("unexpected algorithm " +
+				"params present")
+		}
+		return DecryptJavaKeyEncryption1(keyInfo.EncryptedData,
+			password)
+
+	case keyInfo.Algo.Algorithm.Equal(JavaKeyEncryptionOID2):
+		// TODO: need to implement this
+		return nil, errors.New("not implemented yet")
+
+	default:
+		return nil, fmt.Errorf("unhandled encryption algorithm %v",
+			keyInfo.Algo.Algorithm)
+	}
+}
+
+// MarshalPKCS8 marshals an RSA or EC private key into an (unencrypted)
+// PKCS#8 PrivateKeyInfo structure. It returns the DER-encoded structure.
+func MarshalPKCS8(key interface{}) ([]byte, error) {
+	var ki PrivateKeyInfo
+	switch key := key.(type) {
+	case *rsa.PrivateKey:
+		// we simply put the PKCS#1-encoded key into a wrapper that
+		// says it's an RSA key
+		ki.Algo = pkix.AlgorithmIdentifier{
+			Algorithm:  oidPublicKeyRSA,
+			Parameters: asn1NULL,
+		}
+		ki.PrivateKey = x509.MarshalPKCS1PrivateKey(key)
+
+	case *ecdsa.PrivateKey:
+		// the PKCS#8 wrapper (PrivateKeyInfo) has algorithm set to
+		// identify the elliptic curve key, but needs a parameter to
+		// state the curve.
+		c, err := oidFromNamedCurve(key)
+		if err != nil {
+			return nil, err
+		}
+
+		ki.Algo = pkix.AlgorithmIdentifier{
+			Algorithm: oidPublicKeyECDSA,
+		}
+		ki.Algo.Parameters.FullBytes, err = asn1.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("marshal EC private key "+
+				"params: %v", err)
+		}
+
+		ki.PrivateKey, err = x509.MarshalECPrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("marshal EC private key: %v",
+				err)
+		}
+
+	default:
+		return nil, fmt.Errorf("unhandled private key type %T", key)
+	}
+
+	raw, err := asn1.Marshal(ki)
+	if err != nil {
+		return nil, fmt.Errorf("marshal PrivateKeyInfo: %v", err)
+	}
+	return raw, nil
+}
+
+// oidFromNamedCurve returns an OID which identifies the curve used in the
+// given key.
+func oidFromNamedCurve(key *ecdsa.PrivateKey) (asn1.ObjectIdentifier, error) {
+	switch key.Params().Name {
+	case "P-224":
+		return oidNamedCurveP224, nil
+	case "P-256":
+		return oidNamedCurveP256, nil
+	case "P-384":
+		return oidNamedCurveP384, nil
+	case "P-521":
+		return oidNamedCurveP521, nil
+	}
+	return nil, fmt.Errorf("unknown named curve %q", key.Params().Name)
+}
+
+// DecryptJavaKeyEncryption1 decrypts ciphertext encrypted with one of the Java
+// key encryption algorithms.
+//
+// PLEASE NOTE: this appears to be custom crypto. You should *never* do this. DO
+// NOT RE-USE THIS CODE. If you want an example of how to encrypt a blob of data
+// or a file with a password, then see the password-encrypt example at:
+//  https://github.com/lwithers/go-crypto-examples
+func DecryptJavaKeyEncryption1(ciphertext []byte, password string,
+) ([]byte, error) {
+	// split the blob into salt:ciphertext:digest
+	if len(ciphertext) <= 40 {
+		return nil, errors.New("not enough data for encryption type 1")
+	}
+	salt := ciphertext[:20]
+	digest := ciphertext[len(ciphertext)-20:]
+	ciphertext = ciphertext[20 : len(ciphertext)-20]
+
+	// XOR the SHA-1-derived bytestream with the "ciphertext" to recover
+	// the plaintext
+	passwd := PasswordUTF16(password)
+	xorStream := xorStreamForJavaKeyEncryption1(len(ciphertext),
+		passwd, salt)
+	plaintext := make([]byte, len(ciphertext))
+	for i := range ciphertext {
+		plaintext[i] = ciphertext[i] ^ xorStream[i]
+	}
+
+	// test that the SHA-1 hash over (passwd+plaintext) matches the recorded
+	// digest
+	md := sha1.New()
+	md.Write(passwd)
+	md.Write(plaintext)
+	computed := md.Sum(nil)
+	if !bytes.Equal(computed, digest) {
+		return nil, errors.New("invalid password")
+	}
+
+	return plaintext, nil
+}
+
+// EncryptJavaKeyEncryption1 encrypts plaintext with one of the Java key
+// encryption algorithms.
+//
+// PLEASE NOTE: this appears to be custom crypto. You should *never* do this. DO
+// NOT RE-USE THIS CODE. If you want an example of how to encrypt a blob of data
+// or a file with a password, then see the password-encrypt example at:
+//  https://github.com/lwithers/go-crypto-examples
+func EncryptJavaKeyEncryption1(plaintext []byte, password string,
+) ([]byte, error) {
+	// generate a salt
+	var salt [20]byte
+	if _, err := rand.Read(salt[:]); err != nil {
+		return nil, err
+	}
+
+	// XOR the SHA-1-derived bytestream with the plaintext to derive the
+	// "ciphertext"
+	passwd := PasswordUTF16(password)
+	xorStream := xorStreamForJavaKeyEncryption1(len(plaintext),
+		passwd, salt[:])
+	ciphertext := make([]byte, len(plaintext))
+	for i := range ciphertext {
+		ciphertext[i] = plaintext[i] ^ xorStream[i]
+	}
+
+	// compute the SHA-1 hash over (passwd+plaintext)
+	md := sha1.New()
+	md.Write(passwd)
+	md.Write(plaintext)
+	digest := md.Sum(nil)
+
+	// return salt:ciphertext:digest
+	result := make([]byte, 0, len(salt)+len(ciphertext)+len(digest))
+	result = append(result, salt[:]...)
+	result = append(result, ciphertext...)
+	result = append(result, digest...)
+	return result, nil
+}
+
+// xorStreamForJavaKeyEncryption1 returns a stream of bytes that is XORed with
+// the plaintext to produce the ciphertext.  We iteratively use a SHA-1 hash
+// over (passwd+lastHash) to produce a stream of bytes we then XOR with the
+// "ciphertext". For the first block we use ‘salt’ in place of ‘last_hash’.
+//
+// PLEASE NOTE: this appears to be custom crypto. You should *never* do this. DO
+// NOT RE-USE THIS CODE. If you want an example of how to encrypt a blob of data
+// or a file with a password, then see the password-encrypt example at:
+//  https://github.com/lwithers/go-crypto-examples
+func xorStreamForJavaKeyEncryption1(strlen int, passwd, salt []byte) []byte {
+	xorStream := make([]byte, strlen)
+	wrXor := xorStream
+	lastHash := make([]byte, 20)
+	copy(lastHash, salt)
+
+	for len(wrXor) > 0 {
+		md := sha1.New()
+		md.Write(passwd)
+		md.Write(lastHash)
+		lastHash = md.Sum(lastHash[:0])
+
+		copy(wrXor, lastHash)
+		if len(wrXor) <= 20 {
+			break
+		}
+		wrXor = wrXor[20:]
+	}
+	return xorStream
+}

--- a/pkg/jks/pkcs8_test.go
+++ b/pkg/jks/pkcs8_test.go
@@ -1,0 +1,36 @@
+package jks
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/asn1"
+	"testing"
+)
+
+// TestOIDFromNamedCurve ensures that we return the correct OID identifying the
+// curve for ECDSA private keys.
+func TestOIDFromNamedCurve(t *testing.T) {
+	t.Run("P-224", testOIDFromNamedCurve(oidNamedCurveP224, elliptic.P224()))
+	t.Run("P-256", testOIDFromNamedCurve(oidNamedCurveP256, elliptic.P256()))
+	t.Run("P-384", testOIDFromNamedCurve(oidNamedCurveP384, elliptic.P384()))
+	t.Run("P-521", testOIDFromNamedCurve(oidNamedCurveP521, elliptic.P521()))
+}
+
+func testOIDFromNamedCurve(exp asn1.ObjectIdentifier, curve elliptic.Curve,
+) func(*testing.T) {
+	return func(t *testing.T) {
+		k, err := ecdsa.GenerateKey(curve, rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+
+		oid, err := oidFromNamedCurve(k)
+		switch {
+		case err != nil:
+			t.Errorf("could not find OID: %v", err)
+		case !oid.Equal(exp):
+			t.Errorf("OID %v ≠ expected %v", oid, exp)
+		}
+	}
+}

--- a/pkg/jks/read.go
+++ b/pkg/jks/read.go
@@ -1,0 +1,297 @@
+/*
+Package jks provides routines for manipulating Java Keystore files.
+*/
+package jks
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/x509"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// Parse a JKS file. If desired, opts may be specified to provide more control
+// over the parsing. If nil, then we will use an empty password when attempting
+// to decrypt keys and will not attempt to verify the digest stored in the file.
+//
+// Errors encountered when parsing a certificate, or decrypting or parsing a
+// private key, are stored within the returned Keystore structure. These do not
+// lead to the parse failing and will not be returned as an error by the top
+// level function. Unrecoverable errors (i.e. malformed file) will result in the
+// Parse function returning an error. If digest verification is requested and
+// the password or the digest is incorrect, an error will also be returned. If
+// any useful data has been extracted it will be returned as a partial Keystore.
+func Parse(raw []byte, opts *Options) (*Keystore, error) {
+	if opts == nil {
+		opts = &defaultOptions
+	}
+
+	buf := bytes.NewReader(raw)
+	ks := new(Keystore)
+
+	// read file header
+	magic, _, err := readUint32(buf, "magic header")
+	if err != nil {
+		println("err in magic", err)
+		return nil, err
+	}
+	if magic != MagicNumber {
+		return nil, fmt.Errorf("invalid magic; expected 0x%08X "+
+			"but got 0x%08X", MagicNumber, magic)
+	}
+
+	version, _, err := readUint32(buf, "file version")
+	if err != nil {
+		println("err in version", err)
+		return nil, err
+	}
+	if version != 2 {
+		return nil, fmt.Errorf("found version %d file, but expected "+
+			"version 2", version)
+	}
+
+	numEnts, _, err := readUint32(buf, "number of entries")
+	if err != nil {
+		println("err in entries", err)
+
+		return nil, err
+	}
+
+	// read each entry in turn
+	for n := uint32(0); n < numEnts; n++ {
+		etype, pos, err := readUint32(buf, "entry type")
+		if err != nil {
+			println("err in entry type", err)
+			return ks, err
+		}
+		switch etype {
+		case 1:
+			// it's a private key + cert chain
+			kp, err := readKeypair(buf, opts)
+			if err != nil {
+				return ks, err
+			}
+			ks.Keypairs = append(ks.Keypairs, kp)
+
+		case 2:
+			// it's a certificate
+			cert, err := readCert(buf)
+			if err != nil {
+				return ks, err
+			}
+			ks.Certs = append(ks.Certs, cert)
+
+		default:
+			return nil, fmt.Errorf("unrecognised entry type %d "+
+				"at file position %d", etype, pos)
+		}
+	}
+
+	switch {
+	// there should be exactly 20 bytes left
+	case buf.Len() != 20:
+		return ks, errors.New("malformed digest at end of file")
+
+	case opts.SkipVerifyDigest:
+		return ks, nil
+
+	default:
+		digest := ComputeDigest(raw[:len(raw)-20], opts.Password)
+		if !hmac.Equal(digest, raw[len(raw)-20:]) {
+			return ks, errors.New("digest mismatch")
+		}
+		return ks, nil
+	}
+}
+
+func readUint32(buf *bytes.Reader, desc string,
+) (value uint32, offset int64, err error) {
+	offset, _ = buf.Seek(0, io.SeekCurrent)
+	if buf.Len() < 4 {
+		return 0, offset, fmt.Errorf("unexpected EOF at position %d "+
+			"while reading %s", offset, desc)
+	}
+
+	var raw [4]byte
+	_, _ = buf.Read(raw[:])
+	return binary.BigEndian.Uint32(raw[:]), offset, nil
+}
+
+func readUint64(buf *bytes.Reader, desc string,
+) (value uint64, offset int64, err error) {
+	offset, _ = buf.Seek(0, io.SeekCurrent)
+	if buf.Len() < 8 {
+		return 0, offset, fmt.Errorf("unexpected EOF at position %d "+
+			"while reading %s", offset, desc)
+	}
+
+	var raw [8]byte
+	_, _ = buf.Read(raw[:])
+	return binary.BigEndian.Uint64(raw[:]), offset, nil
+}
+
+func readTimestamp(buf *bytes.Reader) (ts time.Time, offset int64, err error) {
+	ums, offset, err := readUint64(buf, "timestamp")
+	if err != nil {
+		return time.Time{}, offset, err
+	}
+	ms := int64(ums)
+	return time.Unix(ms/1000, (ms%1000)*1e6), offset, nil
+}
+
+func readStr(buf *bytes.Reader, desc string,
+) (value string, offset int64, err error) {
+	offset, _ = buf.Seek(0, io.SeekCurrent)
+	if buf.Len() < 2 {
+		return "", offset, fmt.Errorf("unexpected EOF at position %d "+
+			"while reading %s", offset, desc)
+	}
+
+	var raw [2]byte
+	_, _ = buf.Read(raw[:])
+	strlen := binary.BigEndian.Uint16(raw[:])
+	if buf.Len() < 2 {
+		return "", offset, fmt.Errorf("unexpected EOF at position %d "+
+			"while reading %s (stored length %d)",
+			offset, desc, strlen)
+	}
+
+	str := make([]byte, strlen)
+	_, _ = buf.Read(str)
+	return string(str), offset, nil
+}
+
+func readCert(buf *bytes.Reader) (*Cert, error) {
+	var (
+		offset int64
+		err    error
+		cert   = new(Cert)
+	)
+
+	cert.Alias, offset, err = readStr(buf, "certificate alias")
+	if err != nil {
+		return nil, err
+	}
+
+	cert.Timestamp, _, err = readTimestamp(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	certType, _, err := readStr(buf, "certificate type")
+	if certType != CertType {
+		return nil, fmt.Errorf("unexpected certificate type at "+
+			"position %d; found %q, expected %q",
+			offset, certType, CertType)
+	}
+
+	elen, _, err := readUint32(buf, "encoded certificate length")
+	if err != nil {
+		return nil, err
+	}
+
+	if buf.Len() < int(elen) {
+		return nil, fmt.Errorf("not enough data to read "+
+			"certificate %q at position %d (length %d bytes)",
+			cert.Alias, offset, elen)
+	}
+
+	cert.Raw = make([]byte, elen)
+	_, _ = buf.Read(cert.Raw)
+
+	cert.Cert, cert.CertErr = x509.ParseCertificate(cert.Raw)
+	return cert, nil
+}
+
+func readKeypair(buf *bytes.Reader, opts *Options) (*Keypair, error) {
+	var (
+		offset   int64
+		err      error
+		certType string
+		kp       = new(Keypair)
+	)
+
+	// retrive the key's alias, and use this to search for a password
+	kp.Alias, offset, err = readStr(buf, "certificate alias")
+	if err != nil {
+		return nil, err
+	}
+	passwd, ok := opts.KeyPasswords[kp.Alias]
+	if !ok {
+		// no specific password for this alias, so use the file password
+		passwd = opts.Password
+	}
+
+	kp.Timestamp, _, err = readTimestamp(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	elen, _, err := readUint32(buf, "encrypted private key length")
+	if err != nil {
+		return nil, err
+	}
+
+	if buf.Len() < int(elen) {
+		return nil, fmt.Errorf("not enough data to read "+
+			"private key %q at position %d (length %d bytes)",
+			kp.Alias, offset, elen)
+	}
+
+	kp.EncryptedKey = make([]byte, elen)
+	_, _ = buf.Read(kp.EncryptedKey)
+	kp.RawKey, kp.PrivKeyErr = DecryptPKCS8(kp.EncryptedKey, passwd)
+	if kp.PrivKeyErr == nil {
+		// we should now have a PKCS#8 PrivateKeyInfo, which Go can
+		// parse for us
+		kp.PrivateKey, kp.PrivKeyErr = x509.ParsePKCS8PrivateKey(
+			kp.RawKey)
+	}
+
+	ncerts, _, err := readUint32(buf, "length of certificate chain")
+	if err != nil {
+		return nil, err
+	}
+
+	for n := uint32(0); n < ncerts; n++ {
+		certType, offset, err = readStr(buf, fmt.Sprintf(
+			"certificate type (chain entry #%d for %q)",
+			n+1, kp.Alias))
+		if err != nil {
+			return nil, err
+		}
+		if certType != CertType {
+			return nil, fmt.Errorf("unexpected certificate type "+
+				"%q (expected %q at position %d for chain "+
+				"entry #%d for %q)",
+				certType, CertType, offset, n+1, kp.Alias)
+		}
+
+		elen, _, err = readUint32(buf, fmt.Sprintf(
+			"encoded certificate length (chain entry #%d for %q)",
+			n+1, kp.Alias))
+		if err != nil {
+			return nil, err
+		}
+
+		if buf.Len() < int(elen) {
+			return nil, fmt.Errorf("not enough data to read "+
+				"certificate chain entry #%d for %q at "+
+				"position %d (length %d bytes)",
+				n+1, kp.Alias, offset, elen)
+		}
+
+		kpc := new(KeypairCert)
+		kpc.Raw = make([]byte, elen)
+		_, _ = buf.Read(kpc.Raw)
+		kpc.Cert, kpc.CertErr = x509.ParseCertificate(kpc.Raw)
+
+		kp.CertChain = append(kp.CertChain, kpc)
+	}
+
+	return kp, nil
+}

--- a/pkg/postprocess/jks.go
+++ b/pkg/postprocess/jks.go
@@ -9,18 +9,13 @@ import (
 // JKS checks if a file meets standard
 func JKS(file string) bool {
 
-	opts := &jks.Options{
-		SkipVerifyDigest: true,
-		KeyPasswords:     nil,
-	}
-
 	raw, err := os.ReadFile(file)
 	if err != nil {
 		fmt.Printf("JKS file read Error")
 		return false
 	}
 
-	ks, err := jks.Parse(raw, opts)
+	ks, err := jks.Parse(raw)
 	if err != nil {
 		println("JKS Parse Error", err)
 	}

--- a/pkg/postprocess/jks.go
+++ b/pkg/postprocess/jks.go
@@ -1,0 +1,31 @@
+package postprocess
+
+import (
+	"fmt"
+	"github.com/americanexpress/earlybird/v4/pkg/jks"
+	"os"
+)
+
+// JKS checks if a file meets standard
+func JKS(file string) bool {
+
+	opts := &jks.Options{
+		SkipVerifyDigest: true,
+		KeyPasswords:     nil,
+	}
+
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Printf("JKS file read Error")
+		return false
+	}
+
+	ks, err := jks.Parse(raw, opts)
+	if err != nil {
+		println("JKS Parse Error", err)
+	}
+	if ks != nil && len(ks.Keypairs) > 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -328,7 +328,8 @@ func scanName(file File, rules []Rule, cfg *cfgReader.EarlybirdConfig) (isHit bo
 
 			// Check if the hit has any false positives
 			fpHit := findFalsePositive(hit)
-			if fpHit {
+			isStillHit := hit.postProcess(cfg, &rule)
+			if fpHit || !isStillHit {
 				return false, hit
 			}
 			return true, hit
@@ -598,6 +599,13 @@ func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit b
 			isHit = false
 			break
 		}
+	case rule.Postprocess == "jks":
+		// Skip same key/value pair
+		if cfg.StrictJKS {
+			isHit = postprocess.JKS(hit.Filename)
+			break
+		}
+		isHit = true
 	default:
 		isHit = true
 	}


### PR DESCRIPTION
Today it's reporting finding on all JKS even if there are only public certs init. In this PR, we have added config to support check for keys in the JKS file and if present then only flag the file.

- Added config `--strict-jks`
- Added post processor to check for keys in the file
- Updated Docs for usage.


Usage
```
go run go-earlybird.go --path=/Users/projects/go/earlybird/sample -config=/Users/projects/go/earlybird/config --strict-jks
```
