### PR TITLE
fix(ssn): updated ssn rule to ignore flaging 9xx in first group

### DIFF
--- a/pkg/postprocess/validateSSN.go
+++ b/pkg/postprocess/validateSSN.go
@@ -21,14 +21,14 @@ import (
 	"strings"
 )
 
-//ValidSSN checks if a SSN meets standard
+// ValidSSN checks if a SSN meets standard
 func ValidSSN(ssn string) bool {
 	ssn = strings.Trim(ssn, "\"'\n ")
 	groups := strings.Split(ssn, "-")
 	if len(groups) != 3 {
 		return false
 	}
-	if first, _ := strconv.Atoi(groups[0]); first == 666 || first <= 0 || first > 900 {
+	if first, _ := strconv.Atoi(groups[0]); first == 666 || first <= 0 || first >= 900 {
 		return false
 	} else if second, _ := strconv.Atoi(groups[1]); second <= 0 || second > 99 {
 		return false

--- a/pkg/postprocess/validateSSN_test.go
+++ b/pkg/postprocess/validateSSN_test.go
@@ -53,6 +53,11 @@ func TestValidSSN(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "Test invalid SSN starting with 9",
+			ssn:  "900-12-1234",
+			want: false,
+		},
+		{
 			name: "Test invalid SSN",
 			ssn:  "999-000-0000",
 			want: false,


### PR DESCRIPTION
Updated Rule for SSN. This will fix https://github.com/americanexpress/earlybird/issues/110

- Ignoring finding starting with `9`. Ref: https://secure.ssa.gov/poms.nsf/lnx/0110201035