### PR TITLE
fix(jks-http): updated code to check for pk in jks via http

### DIFF
--- a/pkg/postprocess/jks.go
+++ b/pkg/postprocess/jks.go
@@ -1,21 +1,12 @@
 package postprocess
 
 import (
-	"fmt"
 	"github.com/americanexpress/earlybird/v4/pkg/jks"
-	"os"
 )
 
 // JKS checks if a file meets standard
-func JKS(file string) bool {
-
-	raw, err := os.ReadFile(file)
-	if err != nil {
-		fmt.Printf("JKS file read Error")
-		return false
-	}
-
-	ks, err := jks.Parse(raw)
+func JKS(fileByte []byte) bool {
+	ks, err := jks.Parse(fileByte)
 	if err != nil {
 		println("JKS Parse Error", err)
 	}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -49,7 +49,7 @@ var (
 	tempPattern    = regexp.MustCompile(tempRegex)
 )
 
-//SearchFiles will use the EarlybirdConfig, the provided file list, decompressed zip files and converted files temporary paths to send found secrets to the Hit channel
+// SearchFiles will use the EarlybirdConfig, the provided file list, decompressed zip files and converted files temporary paths to send found secrets to the Hit channel
 func SearchFiles(cfg *cfgReader.EarlybirdConfig, files []File, compressPaths []string, convertPaths []string, hits chan<- Hit) {
 	//Delete tmp file directory when we're done
 	defer DeleteFiles(compressPaths)
@@ -75,7 +75,7 @@ func SearchFiles(cfg *cfgReader.EarlybirdConfig, files []File, compressPaths []s
 	close(hits)
 }
 
-//scanPool searches incoming jobs for secrets and write findings to hits channel
+// scanPool searches incoming jobs for secrets and write findings to hits channel
 func scanPool(cfg *cfgReader.EarlybirdConfig, wg *sync.WaitGroup, jobMutex *sync.Mutex, jobs chan WorkJob, hits chan<- Hit) {
 	//Create duplicate map
 	dupeMap := make(map[string]bool) //HASH:true
@@ -124,7 +124,7 @@ func determineScanFail(cfg *cfgReader.EarlybirdConfig, hit *Hit) bool {
 	return hit.SeverityID <= cfg.SeverityFailLevel && hit.ConfidenceID <= cfg.ConfidenceFailLevel
 }
 
-//contentJobWriter creates work based off file content for scanning
+// contentJobWriter creates work based off file content for scanning
 func contentJobWriter(cfg *cfgReader.EarlybirdConfig, files []File, jobMutex *sync.Mutex, jobs chan WorkJob) {
 	var e error
 	// Loop through each File
@@ -178,7 +178,7 @@ func contentJobWriter(cfg *cfgReader.EarlybirdConfig, files []File, jobMutex *sy
 	}
 }
 
-//nameScanner scans file names for sensitive values
+// nameScanner scans file names for sensitive values
 func nameScanner(cfg *cfgReader.EarlybirdConfig, files []File, hits chan<- Hit) {
 	for _, file := range files {
 		// Scan the filename based on the Filename rules
@@ -199,7 +199,7 @@ func nameScanner(cfg *cfgReader.EarlybirdConfig, files []File, hits chan<- Hit) 
 
 }
 
-//DeleteFiles removes files and folders in target path array
+// DeleteFiles removes files and folders in target path array
 func DeleteFiles(paths []string) {
 	for _, p := range paths {
 		err := os.RemoveAll(p)
@@ -328,7 +328,8 @@ func scanName(file File, rules []Rule, cfg *cfgReader.EarlybirdConfig) (isHit bo
 
 			// Check if the hit has any false positives
 			fpHit := findFalsePositive(hit)
-			isStillHit := hit.postProcess(cfg, &rule)
+
+			isStillHit := hit.filePostProcess(cfg, &rule, file)
 			if fpHit || !isStillHit {
 				return false, hit
 			}
@@ -355,7 +356,7 @@ func readln(r *bufio.Reader) (string, error) {
 	return string(ln), err
 }
 
-//IsIgnoreAnnotation Checks for ignore annotation
+// IsIgnoreAnnotation Checks for ignore annotation
 func IsIgnoreAnnotation(cfg *cfgReader.EarlybirdConfig, line string) bool {
 	for _, annotation := range cfg.AnnotationsToSkipLine {
 		if strings.Contains(line, annotation) {
@@ -377,7 +378,7 @@ func jobFileName(gitRepo, fileName string) string {
 	return fileName
 }
 
-//splitJob splits up the job into an array of jobs if too long otherwise returns a single job
+// splitJob splits up the job into an array of jobs if too long otherwise returns a single job
 func splitJob(inJob WorkJob, worklength int) (work []WorkJob) {
 	//If line isn't too long, just push job to work channel
 	if len(inJob.WorkLine.LineValue) <= worklength {
@@ -401,7 +402,7 @@ func splitJob(inJob WorkJob, worklength int) (work []WorkJob) {
 	return work
 }
 
-//splitSubN Create the overlap string when splitting long strings
+// splitSubN Create the overlap string when splitting long strings
 func splitSubN(s string, n int) []string {
 	runes := []rune(s)
 	chunks := make([]string, 0, len(runes)/n)
@@ -518,6 +519,28 @@ func (hit *Hit) determineSeverity(cfg *cfgReader.EarlybirdConfig, rule *Rule) {
 	hit.SeverityID = rule.Severity
 }
 
+// filePostProcess Check the raw byte content and specific to filename scanner.
+// This is where we want to make decision based on filename but the postprocessing is at content level.
+func (hit *Hit) filePostProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule, file File) (isHit bool) {
+	switch {
+	case rule.Postprocess == "jks":
+		// Only run PK check if --strict-jks is set to true
+		if cfg.StrictJKS {
+			fileBytes := file.Raw
+			// Try to read file from path if file.Raw is nil
+			if fileBytes == nil {
+				fileBytes, _ = os.ReadFile(file.Path)
+			}
+			isHit = postprocess.JKS(fileBytes)
+			break
+		}
+		isHit = true
+	default:
+		isHit = true
+	}
+	return isHit
+}
+
 func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit bool) {
 	fpHit := false
 	if !cfg.IgnoreFPRules {
@@ -599,20 +622,13 @@ func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit b
 			isHit = false
 			break
 		}
-	case rule.Postprocess == "jks":
-		// Skip same key/value pair
-		if cfg.StrictJKS {
-			isHit = postprocess.JKS(hit.Filename)
-			break
-		}
-		isHit = true
 	default:
 		isHit = true
 	}
 	return isHit
 }
 
-//removeTempPrefix removes the temp path prefix if it exists
+// removeTempPrefix removes the temp path prefix if it exists
 func removeTempPrefix(path string) string {
 	if strings.Contains(path, "ebzip") || strings.Contains(path, "ebgit") || strings.Contains(path, "ebconv") {
 		if paths := tempPattern.FindStringSubmatch(path); len(paths) > 1 {

--- a/pkg/scan/structures.go
+++ b/pkg/scan/structures.go
@@ -20,13 +20,13 @@ import (
 	"regexp"
 )
 
-//Rules is the exported definition of the Rules structure for Earlybird
+// Rules is the exported definition of the Rules structure for Earlybird
 type Rules struct {
 	Rules      []Rule `json:"rules"`
 	Searcharea string `json:"Searcharea"`
 }
 
-//Rule Each module config is a set of rules
+// Rule Each module config is a set of rules
 type Rule struct {
 	Code, Severity, Confidence, SolutionID            int
 	Pattern, Caption, Category, Solution, Postprocess string
@@ -36,7 +36,7 @@ type Rule struct {
 	Example                                           string
 }
 
-//Hit is a match in a file against a specific rule
+// Hit is a match in a file against a specific rule
 type Hit struct {
 	Code         int      `json:"code"`
 	Filename     string   `json:"filename"`
@@ -60,6 +60,7 @@ type File struct {
 	Name  string
 	Path  string
 	Lines []Line
+	Raw   []byte
 }
 
 // Line in a file to scan
@@ -84,7 +85,7 @@ type Report struct {
 	Duration      string   `json:"duration"`
 }
 
-//WorkJob As we add jobs to the pool, they need to contain the line being scanned and the file content (in Lines)
+// WorkJob As we add jobs to the pool, they need to contain the line being scanned and the file content (in Lines)
 type WorkJob struct {
 	WorkLine  Line
 	FileLines []Line
@@ -95,7 +96,7 @@ type FalsePositives struct {
 	FalsePositives []FalsePositive `json:"rules"`
 }
 
-//FalsePositive is a rule to match false positives post process
+// FalsePositive is a rule to match false positives post process
 type FalsePositive struct {
 	Codes           []int
 	Pattern         string
@@ -109,13 +110,13 @@ type Solutions struct {
 	Solutions []Solution `json:"solutions"`
 }
 
-//Solution display text for a solution
+// Solution display text for a solution
 type Solution struct {
 	ID   int    `json:"id"`
 	Text string `json:"text"`
 }
 
-//LabelConfig Rule for applying labels to hits based on context
+// LabelConfig Rule for applying labels to hits based on context
 type LabelConfig struct {
 	Label     string   `json:"label"`
 	Keys      []string `json:"keys"`
@@ -124,7 +125,7 @@ type LabelConfig struct {
 	Codes     []int    `json:"codes"`
 }
 
-//LabelConfigs Rules for applying labels to hits based on context
+// LabelConfigs Rules for applying labels to hits based on context
 type LabelConfigs struct {
 	Labels []LabelConfig `json:"Labels"`
 }


### PR DESCRIPTION
### This PR resolves https://github.com/americanexpress/earlybird/issues/117

We have made configuration adjustments to check for jsk file for strict check on private key via `--strict-jks` in https://github.com/americanexpress/earlybird/pull/125. This was only working for the file system scan and not multipart form request while running Earlybird as a service.

**In this PR** 
- Added a check for `.jks` in `MultipartToScanFiles` method and returning Raw file bytes instead of lines
-  Added `filePostProcess()` for filename scanner where we need to report finding based on extension after rendering via file data.
- Remove the `os.ReadFile()` from jks package, since we have raw byte available.  