### PR TITLE
fix(module): updated code to report finding based on module config

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -31,3 +31,27 @@ New modules can be added via json rules files in the user's `go-earlybird` confi
 }
 ```
 We recommend using a unique, integer-only approach to defining the `Code` field.
+
+## Usage of module-config-file:
+We have a provision to provide separate config for each module. This is helpful in case of displaying hits with different severity for each module without over loading rules.
+Ex: List all the hits for password modules with medium severity and display all the findings from inclusivity module.
+
+Here is the module-config.json file.
+
+```json
+{
+  "modules": {
+    "inclusivity-rules": {
+      "display_severity": "info",
+      "display_confidence": "high"
+    }
+  }
+}
+```
+
+Command will be
+```bash
+go run go-earlybird.go -display-severity=high -module-config-file=/Users/projects/eb/earlybird/module-config.json --enable=password-secret --enable=inclusivity-rules
+```
+
+This will avoid loading all(info and low) rules from `password-secret` module, but still it will run with info severity for inclusivity-rules.

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -185,10 +185,7 @@ func nameScanner(cfg *cfgReader.EarlybirdConfig, files []File, hits chan<- Hit) 
 		hitFound, hit := scanName(file, CombinedRules, cfg)
 		if hitFound {
 
-			// Append the hit to our slice for return
-			if cfg.LevelMap[hit.Severity] <= cfg.SeverityDisplayLevel {
-				hits <- hit //push hit to channel
-			}
+			hits <- hit //push hit to channel
 
 			// If a hit severity is less than the failLevel and a hit confidence is less than the failLevel, set failScan = true
 			if cfg.LevelMap[hit.Severity] <= cfg.SeverityFailLevel && cfg.LevelMap[hit.Confidence] <= cfg.ConfidenceFailLevel {


### PR DESCRIPTION
This will fix the issue https://github.com/americanexpress/earlybird/issues/136

- Removed the redundant check for `display-severity` for namescanner
- updated docs for the usage of `module-config-file`