### PR TITLE
fix: log error and continue when error reading compressed file 

### DIFF
--- a/pkg/file/fileUtil.go
+++ b/pkg/file/fileUtil.go
@@ -469,7 +469,10 @@ func GetCompressedFiles(files []scan.File, rootPath string) (newfiles []scan.Fil
 		compresspaths = append(compresspaths, tmppath)
 		filenames, err := Uncompress(file.Path, tmppath)
 		if err != nil {
-			return newfiles, compresspaths, err
+			// We log the error and move on if the file cannot be uncompressed
+			log.Println("Error reading compressed file", file.Path, err)
+			// Read the next file in the list
+			continue
 		}
 		for _, subfile := range filenames {
 			if !isIgnoredFile(subfile, rootPath) && !scan.CompressPattern.MatchString(subfile) {


### PR DESCRIPTION
- fix: error reading compressed file would fail the whole scan.  #138

**Error:**
```
2025/05/19 10:05:11 Go-EarlyBird version:  dev
Severity Fail threshold (at or above):  low
Confidence Fail threshold (at or above):  low
Severity Display threshold (at or above):  medium
Confidence Display threshold (at or above):  high
Max file size to scan:  10240000  bytes
2025/05/19 10:05:11 loading module:  ccnumber
2025/05/19 10:05:11 loading module:  filename
2025/05/19 10:05:11 loading module:  content
2025/05/19 10:05:11 loading module:  password-secret
2025/05/19 10:05:12 Scanning directory:  /EBTest/500001139-lumi-blaze-esbatch
2025/05/19 10:05:12 Failed to get FileContext: zip: not a valid zip file
exit status 1
```