### PR TITLE
feat: adding secret detection in .pem file

### DIFF
--- a/pkg/postprocess/pem.go
+++ b/pkg/postprocess/pem.go
@@ -1,0 +1,65 @@
+package postprocess
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+func isPrivatePem(filePath string) bool {
+	// Read the PEM file
+	pemData, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Printf("Failed to read PEM file %v: %v", filePath, err)
+		return true
+	}
+
+	// Loop through all PEM blocks
+	for {
+		block, rest := pem.Decode(pemData)
+		if block == nil {
+			return false // No more blocks to decode
+		}
+
+		// Print block type
+		fmt.Println("Block Type:", block.Type)
+		if checkPrivate(block.Type) {
+			return true
+		}
+		if checkPublic(block.Type) {
+			pemData = rest
+			continue
+		}
+
+		// Attempt to parse as a private key
+		_, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err == nil {
+			return true
+		}
+
+		// Attempt to parse as a public key
+		_, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err == nil {
+			pemData = rest
+			continue
+		}
+
+		// Update pemData to process the remaining blocks
+		pemData = rest
+	}
+}
+
+func checkPrivate(blockType string) bool {
+	list := []string{"private", "PKCS8"}
+
+	return strings.Contains(strings.Join(list, " "), strings.ToLower(blockType))
+}
+
+func checkPublic(blockType string) bool {
+	list := []string{"public", "certificate", "x509"}
+
+	return strings.Contains(strings.Join(list, " "), strings.ToLower(blockType))
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -532,6 +532,10 @@ func (hit *Hit) filePostProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule, file
 			break
 		}
 		isHit = true
+	case rule.Postprocess == "pem":
+		// check and return if the file is a private PEM file
+		isHit = postprocess.isPrivatePem(file.Path)
+		break
 	default:
 		isHit = true
 	}


### PR DESCRIPTION
PEM files(.pem extension) can hold various types of cryptographic material, including: 
- Private keys
- Public keys
- Certificates
- Certificate chains

a certificate itself does not contain private keys or public keys directly. It references to a public key as part of its structure

The PEM format must follows specific headers to identify the type of data contained in the block. The headers are standardized and must follow this format:
-----BEGIN <TYPE>-----
-----END <TYPE>-----
The <TYPE> defines the content of the block. 

I. Private key type
private key types that can appear in PEM files:
PRIVATE KEY, RSA PRIVATE KEY, EC PRIVATE KEY, ENCRYPTED PRIVATE KEY, DSA PRIVATE KEY, OPENSSH PRIVATE KEY.
To be noted that all the different types of private key has one thing in common, (type has PRIVATE string)

II. certificate 
blockType: CERTIFICATE

III. public key type
blockType: PUBLIC KEY

IV. Other type
1. -----BEGIN X509 CRL-----                    Contains a list of certificates that have been revoked by the Certificate Authority (CA).
2. -----BEGIN PKCS8-----                      Represents PKCS#8 format objects, which can include private keys.
3. -----BEGIN DH PARAMETERS-----             Contains Diffie-Hellman parameters used for secure key exchange.

**We would be only flagging the private key, and rest marking them as false hit.**