### PR TITLE
fix: Updating the file extension matching

### DIFF
--- a/pkg/scan/falsePositives_test.go
+++ b/pkg/scan/falsePositives_test.go
@@ -88,15 +88,6 @@ func Test_findFalsePositive(t *testing.T) {
 			wantIsFP: false,
 		},
 		{
-			name: "skip allowed encrypted CC number",
-			hit: Hit{
-				Code:       6008,
-				Filename:   "aspire.json",
-				MatchValue: `      "account_token": "EPQY2I6OK38NBKM",`,
-			},
-			wantIsFP: true,
-		},
-		{
 			name: "Skip typescript variable assignment",
 			hit: Hit{
 				Code:       3006,

--- a/pkg/scan/scanUtil.go
+++ b/pkg/scan/scanUtil.go
@@ -35,7 +35,7 @@ func findHit(target string, CompiledPattern *regexp.Regexp) (isHit bool, retMatc
 	return false, ""
 }
 
-//substringExistsInLines Search for a regexp pattern occurring anywhere in a file
+// substringExistsInLines Search for a regexp pattern occurring anywhere in a file
 func substringExistsInLines(fileLines []Line, str string) bool {
 	reg := regexp.MustCompile("(?i)" + str)
 	for _, line := range fileLines {
@@ -46,7 +46,7 @@ func substringExistsInLines(fileLines []Line, str string) bool {
 	return false
 }
 
-//substringExistsInString check if sub exists in string
+// substringExistsInString check if sub exists in string
 func substringExistsInString(str string, substr string) bool {
 	m := search.New(language.English, search.IgnoreCase)
 	start, _ := m.IndexString(str, substr)
@@ -98,7 +98,7 @@ func findFalsePositive(hit Hit) (isFP bool) {
 			if len(rule.FileExtensions) > 0 { //Check if this rule only applies to certain files
 				scan = false
 				for _, fileExtension := range rule.FileExtensions { //Cycle through file extensions to verify rule applies to hit
-					if strings.Contains(hit.Filename, fileExtension) {
+					if strings.HasSuffix(strings.ToLower(hit.Filename), strings.ToLower(fileExtension)) {
 						scan = true //Trigger a value scan if the file name matches
 					}
 				}


### PR DESCRIPTION
The file extention matching in the earlybird scan is not accuate, right now it just search for the occurance of the file extention(contains) substring in the actual file name. But it should be matching the last occurrence specifically. 
For example lets consider we have a false positive rule that suppress finding any password secret in file have the extension .c([false-positives.yaml](https://github.com/americanexpress/earlybird/blob/main/config/falsepositives/false-positives.yaml#L814)) and .griddle, one can easily place the secret using this rule in file name with extension such as listed below and easily undetected in the earlybird scan. 
.c, .config, .cc, .class .cmd, .cfg, .cpp, .c#, .cxx, .cp, .cs, .css, .cgi, .cr, .cls, .cmake, .cob, e3.config.yaml, e3.config.secret e3.gradle.yaml
If the file name is e1.config.yaml and has secrets it would be suppressed by false positive rules as we would be suppressing the .config file present in the file name.