### PR TITLE
fix: use defer .Close() to protect against file leakage

### DIFF
--- a/pkg/file/fileUtil.go
+++ b/pkg/file/fileUtil.go
@@ -52,6 +52,7 @@ func MultipartToScanFiles(files []*multipart.FileHeader, cfg cfgreader.Earlybird
 		if err != nil {
 			return fileList, err
 		}
+        defer myfile.Close()
 		// Per the HTTP spec, The filename directive of multipart form data will have it's path information stripped https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition.
 		// .ge_ignore file only works on absolute paths, not the basename of a file
 		// client will send filepath as base64 encoded and earlybird will decode to get the full path
@@ -129,7 +130,6 @@ func MultipartToScanFiles(files []*multipart.FileHeader, cfg cfgreader.Earlybird
 			fileList = append(fileList, curFile)
 		}
 
-		myfile.Close()
 	}
 	return
 }

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -147,6 +147,8 @@ func contentJobWriter(cfg *cfgReader.EarlybirdConfig, files []File, jobMutex *sy
 						log.Fatal("Can't open file", err)
 					}
 				}
+				defer fileOS.Close()
+
 				var work []WorkJob
 				var job WorkJob
 				job.FileLines = searchFile.Lines
@@ -172,7 +174,6 @@ func contentJobWriter(cfg *cfgReader.EarlybirdConfig, files []File, jobMutex *sy
 				for _, job := range work {
 					jobs <- job
 				}
-				fileOS.Close()
 			}
 		}
 	}


### PR DESCRIPTION
In response to a concern raised in https://github.com/americanexpress/earlybird/issues/94. There were a few edge cases where a file was read and not closed because an error was returned before the close command was reached. Using defer .Close() fixes this issue and ensures files are closed regardless of what errors are returned.