### PR TITLE
fix: reuse bytes.Buffer in loop

### DIFF
--- a/pkg/file/fileUtil.go
+++ b/pkg/file/fileUtil.go
@@ -96,8 +96,9 @@ func MultipartToScanFiles(files []*multipart.FileHeader, cfg cfgreader.Earlybird
 
 			var line scan.Line
 			reader := bufio.NewReader(myfile)
+			var buffer bytes.Buffer
 			for {
-				var buffer bytes.Buffer
+				buffer.Reset()
 
 				var l []byte
 				var isPrefix bool


### PR DESCRIPTION
Reusing buffer will improve efficiency by reducing memory allocations and lowering garbage collection pressure.