### PR TITLE
fix: making the addlistener channel as buffered

### DIFF
--- a/pkg/broadcast/broadcast.go
+++ b/pkg/broadcast/broadcast.go
@@ -23,6 +23,7 @@ package broadcast
 
 import (
 	"context"
+
 	"github.com/americanexpress/earlybird/v4/pkg/scan"
 )
 
@@ -55,7 +56,7 @@ func NewBroadcastServer(ctx context.Context, source <-chan scan.Hit) BroadcastSe
 	service := &broadcastServer{
 		source:         source,
 		listeners:      make([]chan scan.Hit, 0),
-		addListener:    make(chan chan scan.Hit),
+		addListener:    make(chan chan scan.Hit, 10),
 		removeListener: make(chan (<-chan scan.Hit)),
 	}
 	go service.serve(ctx)


### PR DESCRIPTION
Deadlock issue brief,

- Issue in the worker thread, while pushing the hit to the hits channel from the worker thread, but cannot able to push it.
- There was a issue with write result also, cannot able to create a subscriber.
- In the job creation, cannot able to push job in the jobs channel.

The subscribe method sends a new listener channel to the addListener channel.
If the server method in the broadcastServer is not actively reading from the addListener channel(the server is not started or the server is busy with other operations), the subscribe method will block indefinitely, causing a deadlock. We would be using an buffered channel for addListener to prevent blocking if the server method is busy.