### PR TITLE
feat: adding post process for basic auth

### DIFF
--- a/pkg/postprocess/basicAuthHeader.go
+++ b/pkg/postprocess/basicAuthHeader.go
@@ -1,0 +1,37 @@
+package postprocess
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// decodeBase64 decodes a Base64-encoded string
+func decodeBase64(encoded string) (string, error) {
+	decodedBytes, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(decodedBytes), nil
+}
+
+func IsBasicAuthHeader(rawText string) bool {
+
+	if !strings.Contains(strings.ToLower(rawText), "authorization") || !strings.Contains(strings.ToLower(rawText), "basic") {
+		return false
+	}
+
+	Index := strings.Index(strings.ToLower(rawText), "basic")
+	encryptedText := ""
+	for i := Index + 5; i < len(rawText); i++ {
+		if rawText[i] == ' ' || rawText[i] == '"' || rawText[i] == '`' || rawText[i] == '$' || rawText[i] == '\'' {
+			continue
+		}
+		encryptedText += string(rawText[i])
+	}
+
+	decodedText, err := decodeBase64(encryptedText)
+	if err != nil || decodedText == "" {
+		return false
+	}
+	return strings.Contains(decodedText, ":") && len(strings.Split(decodedText, ":")) == 2 && len(decodedText) > 2
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -602,6 +602,11 @@ func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit b
 			isHit = true
 		}
 
+	case rule.Postprocess == "basicAuth":
+		if postprocess.IsBasicAuthHeader(hit.MatchValue) {
+			isHit = true
+		}
+
 		// Calculate the entropy of a string and make sure it passes entropyThreshold
 	case rule.Postprocess == "entropy":
 		e := postprocess.Shannon(hit.MatchValue)


### PR DESCRIPTION
Creating a post process for the basic auth as a second layer of validation where we are decrypting the base64 encrypted string and checking whether the decrypted data is in the format of user:password.  The aim is to prevent false positive findings.