### PR TITLE
feat: adding postprocess for basic auth header

### DIFF
--- a/config/rules/password-secret.yaml
+++ b/config/rules/password-secret.yaml
@@ -360,6 +360,20 @@ rules:
       - CWE-798
       - CWE-321
       - CWE-312
+  - Code: 3084
+    Pattern: (?i)(['"]?(Authorization)?['"]?[ \t]*[:=]?[ \t]*['"]?Basic[ \t]*[A-Za-z0-9+=\/]{5,}['"]?)
+    Caption: Potential Basic Auth token in file
+    Category: password-secret
+    Example: 'Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=='
+    SolutionID: 1
+    Severity: 2
+    Confidence: 2
+    Postprocess: basicAuth
+    CWE:
+      - CWE-798
+      - CWE-312
+      - CWE-257
+      - CWE-259
   - Code: 3034
     Pattern: (?i)(['"]client[_-]?secret['"][ \t]*[:=][ \t]*(['"][^'"]{4,}['"]|[0-9a-z\-_@#!%\^\?\*&\$~]{4,}))
     Caption: Potential secret in file

--- a/pkg/postprocess/basicAuthHeader.go
+++ b/pkg/postprocess/basicAuthHeader.go
@@ -1,0 +1,37 @@
+package postprocess
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// decodeBase64 decodes a Base64-encoded string
+func decodeBase64(encoded string) (string, error) {
+	decodedBytes, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(decodedBytes), nil
+}
+
+func IsBasicAuthHeader(rawText string) bool {
+
+	if !strings.Contains(strings.ToLower(rawText), "authorization") || !strings.Contains(strings.ToLower(rawText), "basic") {
+		return false
+	}
+
+	Index := strings.Index(strings.ToLower(rawText), "basic")
+	encryptedText := ""
+	for i := Index + 5; i < len(rawText); i++ {
+		if rawText[i] == ' ' || rawText[i] == '"' || rawText[i] == '`' || rawText[i] == '$' || rawText[i] == '\'' {
+			continue
+		}
+		encryptedText += string(rawText[i])
+	}
+
+	decodedText, err := decodeBase64(encryptedText)
+	if err != nil || decodedText == "" {
+		return false
+	}
+	return strings.Contains(decodedText, ":") && len(strings.Split(decodedText, ":")) == 2 && len(decodedText) > 2
+}

--- a/pkg/postprocess/basicAuthHeader.go
+++ b/pkg/postprocess/basicAuthHeader.go
@@ -16,22 +16,24 @@ func decodeBase64(encoded string) (string, error) {
 
 func IsBasicAuthHeader(rawText string) bool {
 
+	// check if the rawText contains "Authorization" and "Basic" (case-insensitive).  Raw text is expected to looks like this somewhat this Authorization: Basic asdffgfsaf
 	if !strings.Contains(strings.ToLower(rawText), "authorization") || !strings.Contains(strings.ToLower(rawText), "basic") {
 		return false
 	}
 
+	// Getting the start index of base64 encoded text from the header.
 	Index := strings.Index(strings.ToLower(rawText), "basic")
 	encryptedText := ""
 	for i := Index + 5; i < len(rawText); i++ {
-		if rawText[i] == ' ' || rawText[i] == '"' || rawText[i] == '`' || rawText[i] == '$' || rawText[i] == '\'' {
+		if rawText[i] == ' ' || rawText[i] == '"' || rawText[i] == '`' || rawText[i] == '$' || rawText[i] == '\'' { // removing the trailing spaces and quotes if any.
 			continue
 		}
-		encryptedText += string(rawText[i])
+		encryptedText += string(rawText[i]) // appending character to encryptedText
 	}
 
-	decodedText, err := decodeBase64(encryptedText)
+	decodedText, err := decodeBase64(encryptedText) // decoding the base64 encoded text.
 	if err != nil || decodedText == "" {
 		return false
 	}
-	return strings.Contains(decodedText, ":") && len(strings.Split(decodedText, ":")) == 2 && len(decodedText) > 2
+	return strings.Contains(decodedText, ":") && len(strings.Split(decodedText, ":")) == 2 && len(decodedText) > 2 // checking if the decoded text contains ':' and has two parts (username and password).
 }

--- a/pkg/postprocess/basicAuthHeader.go
+++ b/pkg/postprocess/basicAuthHeader.go
@@ -16,8 +16,8 @@ func decodeBase64(encoded string) (string, error) {
 
 func IsBasicAuthHeader(rawText string) bool {
 
-	// check if the rawText contains "Authorization" and "Basic" (case-insensitive).  Raw text is expected to looks like this somewhat this Authorization: Basic asdffgfsaf
-	if !strings.Contains(strings.ToLower(rawText), "authorization") || !strings.Contains(strings.ToLower(rawText), "basic") {
+	// check if the rawText contains "Basic" (case-insensitive).  Raw text is expected to looks like this somewhat this Authorization: Basic dXNlbmFtZTpwYXNzd29yZA==
+	if !strings.Contains(strings.ToLower(rawText), "basic") {
 		return false
 	}
 

--- a/pkg/postprocess/basicAuthHeader_test.go
+++ b/pkg/postprocess/basicAuthHeader_test.go
@@ -21,6 +21,21 @@ func TestIsBasicAuthHeader(t *testing.T) {
 			"Authorization: Basic acdefjhikl",
 			false,
 		},
+		{
+			"Valid Basic Auth Header",
+			"Basic dXNlbmFtZTpwYXNzd29yZA==",
+			true,
+		},
+		{
+			"Empty Basic Auth Header",
+			"Authorization: ",
+			false,
+		},
+		{
+			"Missing Basic Prefix",
+			"dXNlbmFtZTpwYXNzd29yZA==",
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/postprocess/basicAuthHeader_test.go
+++ b/pkg/postprocess/basicAuthHeader_test.go
@@ -21,16 +21,6 @@ func TestIsBasicAuthHeader(t *testing.T) {
 			"Authorization: Basic acdefjhikl",
 			false,
 		},
-		{
-			"garbage in middle - this is handled by the pattern matching",
-			"370000ajlsdklasdj000000002",
-			true,
-		},
-		{
-			"Test AMEX example credit card",
-			"370000000000002",
-			true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/postprocess/basicAuthHeader_test.go
+++ b/pkg/postprocess/basicAuthHeader_test.go
@@ -1,0 +1,42 @@
+package postprocess
+
+import "testing"
+
+func TestIsBasicAuthHeader(t *testing.T) {
+	type args struct {
+		cc string
+	}
+	tests := []struct {
+		name     string
+		header   string
+		isSecret bool
+	}{
+		{
+			"Valid Basic Auth Header",
+			"Authorization: Basic dXNlbmFtZTpwYXNzd29yZA==",
+			true,
+		},
+		{
+			"Invalid Basic Auth Header",
+			"Authorization: Basic acdefjhikl",
+			false,
+		},
+		{
+			"garbage in middle - this is handled by the pattern matching",
+			"370000ajlsdklasdj000000002",
+			true,
+		},
+		{
+			"Test AMEX example credit card",
+			"370000000000002",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBasicAuthHeader(tt.header); got != tt.isSecret {
+				t.Errorf("IsBasicAuthHeader() = %v, want %v", got, tt.isSecret)
+			}
+		})
+	}
+}

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -615,7 +615,10 @@ func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit b
 		if postprocess.IsCard(hit.MatchValue) {
 			isHit = true
 		}
-
+	case rule.Postprocess == "basicAuth":
+		if postprocess.IsBasicAuthHeader(hit.MatchValue) {
+			isHit = true
+		}
 		// Calculate the entropy of a string and make sure it passes entropyThreshold
 	case rule.Postprocess == "entropy":
 		e := postprocess.Shannon(hit.MatchValue)

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -604,6 +604,11 @@ func (hit *Hit) postProcess(cfg *cfgReader.EarlybirdConfig, rule *Rule) (isHit b
 			isHit = true
 		}
 
+	case rule.Postprocess == "basicAuth":
+		if postprocess.IsBasicAuthHeader(hit.MatchValue) {
+			isHit = true
+		}
+
 		// Verify credit card hits against a mod10 check
 	case rule.Postprocess == "mod10":
 		// If the match passed a Luhn/mod-10 check, build a Hit


### PR DESCRIPTION
Creating a post process for the basic auth as a second layer of validation where we are decrypting the base64 encrypted string and checking whether the decrypted data is in the format of user:password. The aim is to prevent false positive findings.