### PR TITLE
Deadlock eh test

### DIFF
--- a/pkg/broadcast/broadcast.go
+++ b/pkg/broadcast/broadcast.go
@@ -39,7 +39,7 @@ type broadcastServer struct {
 
 // Subscribe() creates a subcribtion on broadcastServer.
 func (s *broadcastServer) Subscribe() <-chan scan.Hit {
-	newListener := make(chan scan.Hit)
+	newListener := make(chan scan.Hit, 100)
 	s.listeners = append(s.listeners, newListener)
 
 	return newListener

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -299,7 +299,7 @@ func (eb *EarlybirdCfg) Scan() {
 	eb.WriteResults(start, HitChannel, fileContext, &wg)
 	scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel)
 
-	wg.Wait()
+	wg.Wait() // this wait ensures that all writers goroutine are finished
 
 	utils.DeleteGit(eb.Config.Gitrepo, eb.Config.SearchDir)
 	if eb.Config.FailScan {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"bufio"
-	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -295,14 +294,12 @@ func (eb *EarlybirdCfg) Scan() {
 	}
 	var wg sync.WaitGroup
 	HitChannel := make(chan scan.Hit)
-	ctx, cancel := context.WithCancel(context.Background())
 
 	// Send output to a writer | creating the hit results receiver first.
-	eb.WriteResults(start, HitChannel, fileContext, ctx, &wg)
-	go scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel)
+	eb.WriteResults(start, HitChannel, fileContext, &wg)
+	scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel)
 
 	wg.Wait()
-	cancel()
 
 	utils.DeleteGit(eb.Config.Gitrepo, eb.Config.SearchDir)
 	if eb.Config.FailScan {
@@ -341,22 +338,24 @@ func (eb *EarlybirdCfg) FileContext() (fileContext file.Context, err error) {
 }
 
 // WriteResults reads hits from the channel to the console or target file
-func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, fileContext file.Context, ctx context.Context, wg *sync.WaitGroup) {
+func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, fileContext file.Context, wg *sync.WaitGroup) {
 	// Send output to a writer
 	var err error
 	//
-	if true {
+	if eb.Config.WithConsole && eb.Config.OutputFormat == "json" {
 		// initializing the broadcaster with two listeners, and starting the broadcast server
-		broadcaster := broadcast.NewBroadcastServer(ctx, HitChannel, 2, wg)
+		broadcaster := broadcast.NewBroadcastServer(HitChannel, 2, wg)
 		listener := broadcaster.GetListeners()
 		go func() {
 			defer wg.Done()
 			err = writers.WriteConsole(listener[0], "", eb.Config.ShowFullLine)
 			log.Printf("\n%d files scanned in %s", len(fileContext.Files), time.Since(start))
+			printError(err)
 		}()
 		go func() {
 			defer wg.Done()
 			err = writers.WriteJSON(listener[1], eb.Config, fileContext, eb.Config.OutputFile)
+			printError(err)
 		}()
 	} else {
 		wg.Add(1)
@@ -371,8 +370,12 @@ func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, 
 				err = writers.WriteConsole(HitChannel, eb.Config.OutputFile, eb.Config.ShowFullLine)
 				log.Printf("\n%d files scanned in %s", len(fileContext.Files), time.Since(start))
 			}
+			printError(err)
 		}()
 	}
+}
+
+func printError(err error) {
 	if err != nil {
 		log.Println("Writing Results failed:", err)
 	}

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -295,9 +295,8 @@ func (eb *EarlybirdCfg) Scan() {
 	var wg sync.WaitGroup
 	HitChannel := make(chan scan.Hit)
 
-	// Send output to a writer | creating the hit results receiver first.
-	eb.WriteResults(start, HitChannel, fileContext, &wg)
-	scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel)
+	eb.WriteResults(start, HitChannel, fileContext, &wg)                                                             // Registering the hit receiver.
+	scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel) // sending the hits to the channel from the worker threads running on go-routine.
 
 	wg.Wait() // this wait ensures that all writers goroutine are finished
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -293,11 +293,16 @@ func (eb *EarlybirdCfg) Scan() {
 	if err != nil {
 		log.Fatal("Failed to get FileContext: ", err)
 	}
+	var wg sync.WaitGroup
 	HitChannel := make(chan scan.Hit)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Send output to a writer | creating the hit results receiver first.
+	eb.WriteResults(start, HitChannel, fileContext, ctx, &wg)
 	go scan.SearchFiles(&eb.Config, fileContext.Files, fileContext.CompressPaths, fileContext.ConvertPaths, HitChannel)
 
-	// Send output to a writer
-	eb.WriteResults(start, HitChannel, fileContext)
+	wg.Wait()
+	cancel()
 
 	utils.DeleteGit(eb.Config.Gitrepo, eb.Config.SearchDir)
 	if eb.Config.FailScan {
@@ -336,40 +341,37 @@ func (eb *EarlybirdCfg) FileContext() (fileContext file.Context, err error) {
 }
 
 // WriteResults reads hits from the channel to the console or target file
-func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, fileContext file.Context) {
+func (eb *EarlybirdCfg) WriteResults(start time.Time, HitChannel chan scan.Hit, fileContext file.Context, ctx context.Context, wg *sync.WaitGroup) {
 	// Send output to a writer
 	var err error
-
-	if eb.Config.WithConsole && eb.Config.OutputFormat == "json" {
-		var wg sync.WaitGroup
-		wg.Add(2)
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		broadcaster := broadcast.NewBroadcastServer(ctx, HitChannel)
-		listener1 := broadcaster.Subscribe()
-		listener2 := broadcaster.Subscribe()
+	//
+	if true {
+		// initializing the broadcaster with two listeners, and starting the broadcast server
+		broadcaster := broadcast.NewBroadcastServer(ctx, HitChannel, 2, wg)
+		listener := broadcaster.GetListeners()
 		go func() {
 			defer wg.Done()
-			err = writers.WriteConsole(listener1, "", eb.Config.ShowFullLine)
+			err = writers.WriteConsole(listener[0], "", eb.Config.ShowFullLine)
 			log.Printf("\n%d files scanned in %s", len(fileContext.Files), time.Since(start))
-			log.Printf("\n%d rules observed\n", len(scan.CombinedRules))
 		}()
 		go func() {
 			defer wg.Done()
-			err = writers.WriteJSON(listener2, eb.Config, fileContext, eb.Config.OutputFile)
+			err = writers.WriteJSON(listener[1], eb.Config, fileContext, eb.Config.OutputFile)
 		}()
-		wg.Wait()
 	} else {
-		switch {
-		case eb.Config.OutputFormat == "json":
-			err = writers.WriteJSON(HitChannel, eb.Config, fileContext, eb.Config.OutputFile)
-		case eb.Config.OutputFormat == "csv":
-			err = writers.WriteCSV(HitChannel, eb.Config.OutputFile)
-		default:
-			err = writers.WriteConsole(HitChannel, eb.Config.OutputFile, eb.Config.ShowFullLine)
-			log.Printf("\n%d files scanned in %s", len(fileContext.Files), time.Since(start))
-			log.Printf("\n%d rules observed\n", len(scan.CombinedRules))
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			switch {
+			case eb.Config.OutputFormat == "json":
+				err = writers.WriteJSON(HitChannel, eb.Config, fileContext, eb.Config.OutputFile)
+			case eb.Config.OutputFormat == "csv":
+				err = writers.WriteCSV(HitChannel, eb.Config.OutputFile)
+			default:
+				err = writers.WriteConsole(HitChannel, eb.Config.OutputFile, eb.Config.ShowFullLine)
+				log.Printf("\n%d files scanned in %s", len(fileContext.Files), time.Since(start))
+			}
+		}()
 	}
 	if err != nil {
 		log.Println("Writing Results failed:", err)

--- a/pkg/writers/consoleout.go
+++ b/pkg/writers/consoleout.go
@@ -35,7 +35,7 @@ type issue struct {
 
 var issues = make(map[string]int)
 
-//WriteConsole streams hits from the result channel to the command line or target file
+// WriteConsole streams hits from the result channel to the command line or target file
 func WriteConsole(hits <-chan scan.Hit, fileName string, showFullLine bool) error {
 	// If no filename was passed in, just print to stdout
 	if fileName == "" {
@@ -53,6 +53,7 @@ func WriteConsole(hits <-chan scan.Hit, fileName string, showFullLine bool) erro
 		}
 	}
 	displayIssues()
+	log.Printf("\n%d rules observed\n", len(scan.CombinedRules))
 	return nil
 }
 

--- a/pkg/writers/jsonout.go
+++ b/pkg/writers/jsonout.go
@@ -19,11 +19,12 @@ package writers
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	cfgReader "github.com/americanexpress/earlybird/v4/pkg/config"
 	"github.com/americanexpress/earlybird/v4/pkg/file"
 	"github.com/americanexpress/earlybird/v4/pkg/scan"
-	"os"
-	"time"
 )
 
 // WriteJSON takes the hits, converts them into JSON report and passing report to reportToJSONWriter().
@@ -52,7 +53,7 @@ func WriteJSON(hits <-chan scan.Hit, config cfgReader.EarlybirdConfig, fileConte
 	return err
 }
 
-//reportToJSONWriter Outputs an object as a JSON blob to an output file or console
+// reportToJSONWriter Outputs an object as a JSON blob to an output file or console
 func reportToJSONWriter(v interface{}, fileName string) (s string, err error) {
 	b, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {


### PR DESCRIPTION
## RCA
subscribe method sits at the place where deadlock issue is initiated. We would be making the subscribe function independent from the broadcast server, eliminating the possibility of deadlock caused by the addListener channel. By directly adding the listner into the list. This would aviod the deadlock issue where the server is bussy with other operation and new listerner waiting to be pushed inside the listener list and server is waiting for the listener to be added.

## fix and improvement
- Remove the addListener channel from the `broadcastServer`. We Directly append the new listener to the listeners slice inside the `Subscribe` method. Making the code easier to understand and maintain.  Directly appending to the listeners slice avoids the overhead of using an additional channel.
- Similarly removing the removeListener channel and directly perform the operation to remove a listener from the listeners slice. This simplifies the code and avoids the need for an additional channel. 
- Simplifying the code.
- Creating the Hit listeners prior to the sending the Hits from the Hits scan jobs.
- Moving the wait group and context up in the main thread at the starting of the job.
- Structure enhancement and optimising the broadcast server.  
- Adding abstraction on the broadcast server.
- Structuring the broadcast server in a more optimistic way and easy to understand way.