### PR TITLE
fix: basic auth fp

### DIFF
--- a/pkg/postprocess/basicAuthHeader.go
+++ b/pkg/postprocess/basicAuthHeader.go
@@ -35,5 +35,6 @@ func IsBasicAuthHeader(rawText string) bool {
 	if err != nil || decodedText == "" {
 		return false
 	}
-	return strings.Contains(decodedText, ":") && len(strings.Split(decodedText, ":")) == 2 && len(decodedText) > 2 // checking if the decoded text contains ':' and has two parts (username and password).
+	colonIndex := strings.Index(decodedText, ":")
+	return colonIndex != -1 && colonIndex != 0 && colonIndex != len(decodedText)-1 && len(decodedText) > 2 // checking if the decoded text contains ':' and has two parts (username and password).
 }


### PR DESCRIPTION
Fixing the basic auth false positive. The expected text should be in format user:passwor

Fix
Basically checking the four condition for the decreypted text to fullfill.
i. colon should be present in the strings.
ii. colon should not be present at the begining.
iii. colon should not be present at the end.
iv the length of of the decrypted text should be greater than 2.