### PR TITLE
fix: error with nil pointer on symlink check

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -142,9 +142,10 @@ func contentJobWriter(cfg *cfgReader.EarlybirdConfig, files []File, jobs chan Wo
 			//Don't do file read/scan on files we know will trigger the filename scan -- Don't open compressed files either
 			if !isExcludedFileType(cfg, searchFile.Name) && len(CompressPattern.FindStringSubmatch(searchFile.Name)) <= 0 {
 				fileInfo, err := os.Lstat(searchFile.Path)
-				if err != nil && fileInfo != nil && fileInfo.Mode()&fs.ModeSymlink != 0 {
+				if err == nil && fileInfo != nil && fileInfo.Mode()&fs.ModeSymlink != 0 {
 					continue
 				}
+
 				fileOS, err := os.Open(searchFile.Path) //Open file path
 				if err != nil {
 					fileOS, err = os.Open(searchFile.Name) //If file path open fails, try file name


### PR DESCRIPTION
Fixing Error
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x78a22c]
goroutine 30 [running]:
github.com/americanexpress/earlybird/v4/pkg/scan.contentJobWriter(0x1182320, {0xc00088c000?, 0xc0003d0ad0?, 0xc000a5f8f0?}, 0xc000a5f8f0)
 /go/pkg/mod/github.com/americanexpress/earlybird/v4@v4.4.5/pkg/scan/scan.go:144 +0x14c
github.com/americanexpress/earlybird/v4/pkg/scan.SearchFiles(0x1182320, {0xc00088c000, 0x46d, 0x600}, {0xc000540030?, 0x0?, 0x0?}, {0x0, 0x0, 0x0}, ...)
 /go/pkg/mod/github.com/americanexpress/earlybird/v4@v4.4.5/pkg/scan/scan.go:71 +0x1c7
created by github.com/americanexpress/earlybird/v4/pkg/core.(*EarlybirdCfg).Scan in goroutine 1
 /go/pkg/mod/github.com/americanexpress/earlybird/v4@v4.4.5/pkg/core/core.go:297 +0x2f1
```