### PR TITLE
docs: refine wording and consistency

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,15 +3,15 @@
 #### Last Modified: January 29, 2016
 
 Welcome to the American Express Open Source Community on GitHub! These American Express Community
-Guidelines outline our expectations for Github participating members within the American Express
+Guidelines outline our expectations for GitHub participating members within the American Express
 community, as well as steps for reporting unacceptable behavior. We are committed to providing a
 welcoming and inspiring community for all and expect our community Guidelines to be honored.
 
 **IMPORTANT REMINDER:**
 
 When you visit American Express on any third party sites such as GitHub your activity there is
-subject to that site’s then current terms of use., along with their privacy and data security
-practices and policies. The Github platform is not affiliated with us and may have practices and
+subject to that site’s then current terms of use, along with their privacy and data security
+practices and policies. The GitHub platform is not affiliated with us and may have practices and
 policies that are different than are our own.
 
 Please note, American Express is not responsible for, and does not control, the GitHub site’s terms
@@ -55,7 +55,7 @@ to food, health, parenting, drugs, and employment
 - Deliberate misgendering. This includes deadnaming or persistently using a pronoun that does not
 correctly reflect a person's gender identity. You must address people by the name they give you when
 not addressing them by their username or handle
-- Physical contact and simulated physical contact (eg, textual descriptions like “hug” or “backrub”)
+- Physical contact and simulated physical contact (e.g., textual descriptions like “hug” or “backrub”)
 without consent or after a request to stop
 - Threats of violence, both physical and psychological
 - Incitement of violence towards any individual, including encouraging a person to commit suicide
@@ -114,7 +114,7 @@ protecting victims of abuse.
 
 ### Removal of Posts
 We will not review every comment or post, but we reserve the right to remove any that violates these
-Guidelines or that, in our sole discretion, we otherwise consider objectionable and we may ban
+Guidelines or that, in our sole discretion, we otherwise consider objectionable, and we may ban
 offenders from our community.
 
 ### Suspension/Termination/Reporting to Authority

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Logo](docs/GoEarlyBird-logo_sm.png)
 
-EarlyBird is a sensitive data detection tool capable of scanning source code repositories for clear text password violations, PII, outdated cryptography methods, key files and more. It can be used to scan remote git repositories, local files or directories or as a pre-commit step.
+EarlyBird is a sensitive data detection tool capable of scanning source code repositories for clear text password violations, PII, outdated cryptography methods, key files, and more. It can be used to scan remote Git repositories, local files or directories or as a pre-commit step.
 
 ## Prerequisites
 Before running the `build` and `install` scripts on your local machine, you must ensure that `go` is installed locally on your machine. The following command can be
@@ -10,13 +10,13 @@ used to check whether go has been installed.
 go version
 ```
 
-If `go` is not installed locally on your machine, then you ned to ensure that it is installed and the above command works on your local machine. The latest version of `go` can be downloaded from the following link.
+If `go` is not installed locally on your machine, then you need to ensure that it is installed and the above command works on your local machine. The latest version of `go` can be downloaded from the following link.
 
 https://go.dev/dl/
 
 ## Installation
 ### Linux & Mac
-Running the `build.sh` script will produce a binary for each OS, while the `install.sh` script will install Earlybird on your system. This will create a `.go-earlybird` directory in your home directory with all the configuration files. Finally installing `go-earlybird` as an executable in `/usr/local/bin/`.
+Running the `build.sh` script will produce a binary for each OS, while the `install.sh` script will install EarlyBird on your system. This will create a `.go-earlybird` directory in your home directory with all the configuration files. Finally, the `install.sh` script installs `go-earlybird` as an executable in `/usr/local/bin/`.
 ```
 ./build.sh && ./install.sh
 ```
@@ -44,10 +44,10 @@ $ go-earlybird --git=https://github.com/americanexpress/earlybird
 
 
 ## Documentation
- - [Usage - How do I use Earlybird?](./docs/USAGE.md)
+ - [Usage - How do I use EarlyBird?](./docs/USAGE.md)
  - [Modules - What is a Module? How do I create one?](./docs/MODULES.md)
- - [Hooks - How do I use Earlybird as Pre-Commit Hook?](./docs/HOOKS.md)
- - [REST API - How do I use Earlybird as REST API?](./docs/REST.md)
+ - [Hooks - How do I use EarlyBird as Pre-Commit Hook?](./docs/HOOKS.md)
+ - [REST API - How do I use EarlyBird as a REST API?](./docs/REST.md)
  - [False Positives - How are they managed? How do I filter them?](./docs/FALSEPOSITIVES.md)
  - [Labels - What are labels? How do I create my own?](./docs/LABELS.md)
  - [Ignore - How do I skip lines or files intentionally?](./docs/IGNORE.md)
@@ -70,11 +70,11 @@ The MITRE Corporation provides a catalog of [Common Weakness Enumerations](https
 ---
 
 ## Contributing
-We welcome your interest in the American Express Open Source Community on Github. Any Contributor to
+We welcome your interest in the American Express Open Source Community on GitHub. Any Contributor to
 any Open Source Project managed by the American Express Open Source Community must accept and sign
 an Agreement indicating agreement to the terms below. Except for the rights granted in this 
-Agreement to American Express and to recipients of software distributed by American Express, You
-reserve all right, title, and interest, if any, in and to your contributions. Please
+Agreement to American Express and to recipients of software distributed by American Express, you
+reserve all rights, title, and interest, if any, in and to your contributions. Please
 [fill out the Agreement](https://cla-assistant.io/americanexpress/earlybird).
 
 ## License

--- a/docs/CONVERSION.md
+++ b/docs/CONVERSION.md
@@ -1,5 +1,5 @@
 ### Converting PDF and rtf files
-The standalone Earlybird binary cannot convert PDF or rtf files to binary. To enable scanning of these file types, install the following dependencies:
+The standalone EarlyBird binary cannot convert PDF or rtf files to binary. To enable scanning of these file types, install the following dependencies:
 ```bash
 brew install poppler-utils wv unrtf tidy
 go get github.com/JalfResi/justext

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -16,7 +16,7 @@ fi
 *(NOTE: To run the pre-commit hook without failing the commit, you can remove the `exit 1` line, although we recommend keeping the commit-blocking in place)*
 &nbsp;
 
-The following is an example of running EarlyBird from package.json against a local repository before commit, failing the commit if high or critical issues are found (requires git-bash on windows):
+The following is an example of running EarlyBird from package.json against a local repository before commit, failing the commit if high or critical issues are found (requires git-bash on Windows):
 ```
 {
   "name": "demoproj",

--- a/docs/INCLUSIVITY.md
+++ b/docs/INCLUSIVITY.md
@@ -1,4 +1,4 @@
-### Performing a inclusivity scan
+### Performing an inclusivity scan
 
 ```bash
 go-earlybird -path /dir/to/scan -enable inclusivity-rules --display-severity=info

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -10,7 +10,7 @@ Modules are configurable rule sets that define patterns and target areas for sea
  &nbsp;
  
 ## Creating New Modules:
-New modules can be added via json rules files in the user's `go-earlybird` configuration directory.  Simply add a new json file into this directory (e.g. `custom-rules.json`) with the following structure, and EarlyBird will detect and load the rules.  Keeping these custom rules in a separate file will ensure they do not get overwritten when EarlyBird is updated.
+New modules can be added via JSON rules files in the user's `go-earlybird` configuration directory.  Simply add a new JSON file into this directory (e.g. `custom-rules.json`) with the following structure, and EarlyBird will detect and load the rules.  Keeping these custom rules in a separate file will ensure they do not get overwritten when EarlyBird is updated.
 ```
 {
     "Searcharea": "<Where in the file should the scan search?  Supports `body` or `filename`>",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,7 @@
 ## <a name="running"></a> Running Go-EarlyBird
 
 ### <a name="standalone"></a> Standalone
-Assuming the setup script was run, you can kick off the application by running 'go-earlybird' / 'go-earlybird.exe' / 'go-earlybird-linux (mac / windows / linux).  See the *Usage* section below
+Assuming the setup script was run, you can kick off the application by running 'go-earlybird' / 'go-earlybird.exe' / 'go-earlybird-linux' (Mac / Windows / Linux).  See the *Usage* section below.
 
 If Go is installed, the project can be downloaded and run with `go run go-earlybird.go`
 
@@ -20,7 +20,7 @@ Using the `-stream` flag, users can stream or pipe file contents to 'go-earlybir
 ```
 ᐅ go-earlybird --http 0.0.0.0:3000
 ```
-`/scan` will accept a multi-part upload and scan the contents, returning json output.
+`/scan` will accept a multi-part upload and scan the contents, returning JSON output.
 
 The normal HTTP listener will operate on HTTP/1.1.  Go-EarlyBird can be run as HTTPS/2 with the `-https [ip:port]` flag.  Note that this also requires the `-https-cert [/path/to/cert]` and `-https-key [/path/to/key]` parameters.
 


### PR DESCRIPTION
### Change Description
- Improve grammar, punctuation, and naming consistency in README, docs, and Code of Conduct.
- Keep technical behavior unchanged (documentation/text only plus comment clarification).

___

NOTE: There are no code changes, as part of this pull request.