### PR TITLE
fix: adding check for amex

### DIFF
--- a/config/rules/ccnumber.yaml
+++ b/config/rules/ccnumber.yaml
@@ -16,10 +16,22 @@
 Searcharea: body
 rules:
   - Code: 2001
-    Pattern: "[^\\.](\\b3[47]\\d{13}\\b)"
+    Pattern: "[^\\.-]\\b3[47]\\d{2}(\\d{6}| \\d{6} |-\\d{6}-)\\d{5}[^\\w-]"
     Caption: Potential American Express credit card number in file
     Category: cc-number
     Example: '"378282246310005"'
+    SolutionID: 7
+    Severity: 2
+    Confidence: 2
+    Postprocess: mod10
+    CWE:
+      - CWE-312
+
+  - Code: 2008
+    Pattern: "[^\\.](\\b(xx|XX|__)?\\d{2}(\\d{6}| \\d{6} |-\\d{6}-)\\d{5}\\b)"
+    Caption: Potential Amex credit card number in file where first two obvious digits are masked
+    Category: cc-number
+    Example: "\"xx8282246310005\""
     SolutionID: 7
     Severity: 2
     Confidence: 2

--- a/pkg/postprocess/luhn.go
+++ b/pkg/postprocess/luhn.go
@@ -25,7 +25,7 @@ var (
 	delta  = []int{0, 1, 2, 3, 4, -4, -3, -2, -1, 0}
 )
 
-//IsCard Run a mod10 check on a potential card number
+// IsCard Run a mod10 check on a potential card number
 func IsCard(cc string) bool {
 	cc = isolateNumber(cc)
 	if len(cc) == 0 {
@@ -41,6 +41,9 @@ func IsCard(cc string) bool {
 			checksum += delta[cn]
 		}
 		bOdd = !bOdd
+	}
+	if len(card) == 13 { // checking if the first 2 digits are 34 or 37 for AMEX.
+		return (checksum+8)%10 == 0 || (checksum+11)%10 == 0
 	}
 	return checksum%10 == 0
 }

--- a/pkg/postprocess/luhn.go
+++ b/pkg/postprocess/luhn.go
@@ -45,6 +45,7 @@ func IsCard(cc string) bool {
 	if len(card) == 13 { // checking if the first 2 digits are 34 or 37 for AMEX.
 		return (checksum+8)%10 == 0 || (checksum+11)%10 == 0
 	}
+
 	return checksum%10 == 0
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -297,13 +297,12 @@ func scanLine(line Line, fileLines []Line, cfg *cfgReader.EarlybirdConfig) (isHi
 
 // Take a filename and run through the rules, looking for a hit
 func scanName(file File, rules []Rule, cfg *cfgReader.EarlybirdConfig) (isHit bool, hit Hit) {
+	if file.Path == "buffer" {
+		file.Path = file.Name
+	}
 	for _, rule := range rules {
 		if rule.Searcharea == "body" { //Skip rules that do not apply
 			continue
-		}
-
-		if file.Path == "buffer" {
-			file.Path = file.Name
 		}
 
 		patternMatch, _ := findHit(file.Path, rule.CompiledPattern)


### PR DESCRIPTION
Updating the lunh check post-process for 13 digit credit card match found so that if the first 2 digits is either removed or replaced by a place holder(** or -- or XX) for amex credit card. Then we add  34 and 37 and check whether it is an amex credit card or not.
