### PR TITLE
fix: correct overlap behavior for long line chunk splitting

### DIFF
--- a/pkg/scan/falsePositives_test.go
+++ b/pkg/scan/falsePositives_test.go
@@ -108,8 +108,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip JSON same key same value",
 			hit: Hit{
-				Code:     3026,
-				Filename: "test.json",
+				Code:      3026,
+				Filename:  "test.json",
 				LineValue: `		"secret" : "secret"`,
 			},
 			wantIsFP: true,
@@ -117,8 +117,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip JS same key same value",
 			hit: Hit{
-				Code:     3026,
-				Filename: "test.json",
+				Code:      3026,
+				Filename:  "test.json",
 				LineValue: `		'secret' : 'secret'`,
 			},
 			wantIsFP: true,
@@ -126,8 +126,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret",
 			hit: Hit{
-				Code:     3026,
-				Filename: "test.json",
+				Code:      3026,
+				Filename:  "test.json",
 				LineValue: `		"secret" : "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -135,8 +135,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual client-secret",
 			hit: Hit{
-				Code:     3033,
-				Filename: "test.yaml",
+				Code:      3033,
+				Filename:  "test.yaml",
 				LineValue: `		client-secret: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -144,8 +144,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual clientSecret",
 			hit: Hit{
-				Code:     3033,
-				Filename: "test.json",
+				Code:      3033,
+				Filename:  "test.json",
 				LineValue: `		clientSecret: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -153,8 +153,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual 'clientSecret'",
 			hit: Hit{
-				Code:     3034,
-				Filename: "test.json",
+				Code:      3034,
+				Filename:  "test.json",
 				LineValue: `		"clientSecret": "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -162,8 +162,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual client-secret",
 			hit: Hit{
-				Code:     3034,
-				Filename: "test.json",
+				Code:      3034,
+				Filename:  "test.json",
 				LineValue: `		"client-secret": "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -189,8 +189,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual auth-key",
 			hit: Hit{
-				Code:     3035,
-				Filename: "test.yaml",
+				Code:      3035,
+				Filename:  "test.yaml",
 				LineValue: `		auth-key: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -198,8 +198,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual auth-key",
 			hit: Hit{
-				Code:     3035,
-				Filename: "test.json",
+				Code:      3035,
+				Filename:  "test.json",
 				LineValue: `		"auth-key": "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -207,8 +207,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret-key",
 			hit: Hit{
-				Code:     3036,
-				Filename: "test.json",
+				Code:      3036,
+				Filename:  "test.json",
 				LineValue: `		secret-key: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -216,8 +216,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret-key",
 			hit: Hit{
-				Code:     3036,
-				Filename: "test.json",
+				Code:      3036,
+				Filename:  "test.json",
 				LineValue: `		"secret-key": "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -225,8 +225,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip credenitals placeholder",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.yaml",
+				Code:       3075,
+				Filename:   "test.yaml",
 				MatchValue: `		credentials: ******`,
 			},
 			wantIsFP: true,
@@ -234,8 +234,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual credentials in yaml",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.yaml",
+				Code:       3075,
+				Filename:   "test.yaml",
 				MatchValue: `		credentials: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -243,8 +243,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual credential in json",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.json",
+				Code:       3075,
+				Filename:   "test.json",
 				MatchValue: `		"credential": "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -252,8 +252,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual credential in yaml",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.yaml",
+				Code:       3075,
+				Filename:   "test.yaml",
 				MatchValue: `		credential: do_not_use_this_in_production`,
 			},
 			wantIsFP: false,
@@ -297,8 +297,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip false positive predefined credentials (include) from Fetch API",
 			hit: Hit{
-				Code:     3075,
-				Filename: "source.js",
+				Code:       3075,
+				Filename:   "source.js",
 				MatchValue: `		credentials=include`,
 			},
 			wantIsFP: true,
@@ -306,8 +306,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip predefined credentials [omit] from Fetch API",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.ts",
+				Code:      3075,
+				Filename:  "test.ts",
 				LineValue: `		"credentials" : "omit"`,
 			},
 			wantIsFP: true,
@@ -315,8 +315,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip predefined credentials (same-origin) from Fetch API",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.ts",
+				Code:      3075,
+				Filename:  "test.ts",
 				LineValue: `		'credentials' : 'same-origin'`,
 			},
 			wantIsFP: true,
@@ -324,8 +324,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Donot Skip predefined credentials (same-origin) from Fetch API in java file",
 			hit: Hit{
-				Code:     3075,
-				Filename: "test.java",
+				Code:      3075,
+				Filename:  "test.java",
 				LineValue: `		'credentials' : 'same-origin'`,
 			},
 			wantIsFP: false,
@@ -351,8 +351,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret",
 			hit: Hit{
-				Code:     3001,
-				Filename: "test.json",
+				Code:      3001,
+				Filename:  "test.json",
 				LineValue: `		"INPUT_LABEL_GENERIC_PASSWORD": "xxxxxx"`,
 			},
 			wantIsFP: false,
@@ -360,8 +360,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret",
 			hit: Hit{
-				Code:     3001,
-				Filename: "test.properties",
+				Code:      3001,
+				Filename:  "test.properties",
 				LineValue: `		INPUT_LABEL_GENERIC_PASSWORD= xxxxxxxx`,
 			},
 			wantIsFP: false,
@@ -369,8 +369,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual secret",
 			hit: Hit{
-				Code:     3001,
-				Filename: "test.properties",
+				Code:      3001,
+				Filename:  "test.properties",
 				LineValue: `		INPUT_LABEL_GENERIC_PASSWORD= "xxxxxxxx"`,
 			},
 			wantIsFP: false,
@@ -378,8 +378,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual .swift secret",
 			hit: Hit{
-				Code:     3057,
-				Filename: "test.swift",
+				Code:      3057,
+				Filename:  "test.swift",
 				LineValue: `		let password = "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -387,8 +387,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't skip actual .swift secret",
 			hit: Hit{
-				Code:     3057,
-				Filename: "test.swift",
+				Code:      3057,
+				Filename:  "test.swift",
 				LineValue: `		let password: String! = "do_not_use_this_in_production"`,
 			},
 			wantIsFP: false,
@@ -396,8 +396,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip .swift FP",
 			hit: Hit{
-				Code:     3057,
-				Filename: "test.swift",
+				Code:       3057,
+				Filename:   "test.swift",
 				MatchValue: `		var txtFieldPassword: UITextField! = nil`,
 			},
 			wantIsFP: true,
@@ -405,8 +405,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip swedish for password(Lösenord) as value",
 			hit: Hit{
-				Code:     3001,
-				Filename: "source.json",
+				Code:      3001,
+				Filename:  "source.json",
 				LineValue: `		"Password": "Lösenord"`,
 			},
 			wantIsFP: true,
@@ -414,8 +414,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip swedish for password(Lösenord) as value in properties file",
 			hit: Hit{
-				Code:     3001,
-				Filename: "source.properties",
+				Code:      3001,
+				Filename:  "source.properties",
 				LineValue: `		"Password"= "Lösenord"`,
 			},
 			wantIsFP: true,
@@ -540,8 +540,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip private Key as string",
 			hit: Hit{
-				Code:     3023,
-				Filename: "source.java",
+				Code:      3023,
+				Filename:  "source.java",
 				LineValue: `		"'{{' .Data.data.privateKey | regexReplaceAll \"-----BEGIN RSA PRIVATE KEY-----\"`,
 			},
 			wantIsFP: true,
@@ -549,8 +549,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Don't Skip real private Key",
 			hit: Hit{
-				Code:     3023,
-				Filename: "source.java",
+				Code:       3023,
+				Filename:   "source.java",
 				MatchValue: `		-----BEGIN RSA PRIVATE KEY-----`,
 			},
 			wantIsFP: false,
@@ -585,8 +585,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip password using getString",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.scala",
+				Code:      3057,
+				Filename:  "source.scala",
 				LineValue: `		val DBpassword = appConfig.getString("db.jdbc.pwd")`,
 			},
 			wantIsFP: true,
@@ -594,8 +594,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip password that is a function",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.xml",
+				Code:      3057,
+				Filename:  "source.xml",
 				LineValue: `		String password = context.decrypt("%%MONGO_DB_PWD%%");`,
 			},
 			wantIsFP: true,
@@ -603,8 +603,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip password that is a function",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.xml",
+				Code:      3057,
+				Filename:  "source.xml",
 				LineValue: `		password = generatePassword(context)`,
 			},
 			wantIsFP: true,
@@ -612,8 +612,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Do not skip password in logger",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.xml",
+				Code:      3057,
+				Filename:  "source.xml",
 				LineValue: `		logger.debug("Password is : generatePassword :data :" + data);`,
 			},
 			wantIsFP: false,
@@ -657,8 +657,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip password that is is being read from array",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.xml",
+				Code:      3057,
+				Filename:  "source.xml",
 				LineValue: `		String password = param[0];`,
 			},
 			wantIsFP: true,
@@ -666,8 +666,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Do not skip password that is is not being read from array",
 			hit: Hit{
-				Code:     3057,
-				Filename: "source.xml",
+				Code:      3057,
+				Filename:  "source.xml",
 				LineValue: `		String password = pa$$[@ee4@]`,
 			},
 			wantIsFP: false,
@@ -675,8 +675,8 @@ func Test_findFalsePositive(t *testing.T) {
 		{
 			name: "Skip token as variable definitions",
 			hit: Hit{
-				Code:     3037,
-				Filename: "source.kt",
+				Code:      3037,
+				Filename:  "source.kt",
 				LineValue: `	const val AUTHORIZATION_TOKEN = "Authorization Token",`,
 			},
 			wantIsFP: true,

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -418,37 +418,21 @@ func splitSubN(s string, n int) []string {
 		}
 	}
 
-	results := []string{}
-	//subs contains all split strings
-	//iterate over strings parsing
-	toggle := true
-	for _, sub := range chunks {
-		var tmpString string
-		if toggle { // Check if we should parse from the end of the string
-			toggle = false
-			results = append(results, sub) // Append split string
-			if len(sub) >= overlapLength {
-				tmpString = sub[len(sub)-overlapLength:]
-			} else {
-				if len(sub) > 0 {
-					tmpString = sub[len(sub)-(len(sub)-1):]
-				} else {
-					tmpString = sub[0:]
-				}
-			}
-			continue
+	if len(chunks) == 0 {
+		return []string{}
+	}
+
+	results := []string{chunks[0]}
+	for i := 1; i < len(chunks); i++ {
+		prev := chunks[i-1]
+		cur := chunks[i]
+
+		if len(prev) >= overlapLength && len(cur) >= overlapLength {
+			bridge := prev[len(prev)-overlapLength:] + cur[:overlapLength]
+			results = append(results, bridge)
 		}
-		// parse from the start of the string
-		toggle = true
-		if len(sub) > overlapLength {
-			tmpString = tmpString + sub[0:overlapLength-1]
-			results = append(results, tmpString) //Append overlapped data
-			results = append(results, sub)       // Append split string
-			tmpString = ""
-		} else {
-			results = append(results, sub) // Append split string
-			break                          //stop if last element is too short
-		}
+
+		results = append(results, cur)
 	}
 	return results
 }

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -468,6 +468,31 @@ func Test_splitSubN(t *testing.T) {
 			},
 			want: []string{"foo", "bar"},
 		},
+		{
+			name: "Split with overlap bridge",
+			args: args{
+				s: "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGH",
+				n: 30,
+			},
+			want: []string{
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZABCD",
+				"FGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+				"EFGHIJKLMNOPQRSTUVWXYZABCDEFGH",
+			},
+		},
+		{
+			name: "Split builds overlap for every adjacent pair",
+			args: args{
+				s: "aaaaaxxSECRETyyzzzzz",
+				n: 5,
+			},
+			want: []string{
+				"aaaaa",
+				"xxSEC",
+				"RETyy",
+				"zzzzz",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/scan/structures.go
+++ b/pkg/scan/structures.go
@@ -38,21 +38,21 @@ type Rule struct {
 
 // Hit is a match in a file against a specific rule
 type Hit struct {
-	Code         int      `json:"code"`
-	Filename     string   `json:"filename"`
-	Caption      string   `json:"caption"`
-	Category     string   `json:"category"`
-	MatchValue   string   `json:"match_value"`
-	LineValue    string   `json:"line_value"`
-	Solution     string   `json:"solution"`
-	Line         int      `json:"line"`
-	Severity     string   `json:"severity"`
-	SeverityID   int      `json:"severity_id"`
-	Confidence   string   `json:"confidence"`
-	ConfidenceID int      `json:"confidence_id"`
-	Labels       []string `json:"labels"`
-	CWE          []string `json:"cwe"`
-	Time         string   `json:"time"`
+	Code          int      `json:"code"`
+	Filename      string   `json:"filename"`
+	Caption       string   `json:"caption"`
+	Category      string   `json:"category"`
+	MatchValue    string   `json:"match_value"`
+	LineValue string `json:"line_value"`
+	Solution      string   `json:"solution"`
+	Line          int      `json:"line"`
+	Severity      string   `json:"severity"`
+	SeverityID    int      `json:"severity_id"`
+	Confidence    string   `json:"confidence"`
+	ConfidenceID  int      `json:"confidence_id"`
+	Labels        []string `json:"labels"`
+	CWE           []string `json:"cwe"`
+	Time          string   `json:"time"`
 }
 
 // File to scan
@@ -65,7 +65,7 @@ type File struct {
 
 // Line in a file to scan
 type Line struct {
-	LineNum                       int
+	LineNum                                      int
 	LineValue, FilePath, FileName string
 }
 


### PR DESCRIPTION
## Description

The overlap helper for long-line splitting was broken and did not actually preserve the previous chunk’s trailing context, so chunks were scanned with even less surrounding context than intended.

The scenario can be most accurately understood by [this new test case](https://github.com/americanexpress/earlybird/pull/223/changes#diff-859a6c17dd90e351f05cf22a48976998a5818875012f92c87ec680aa465ad00bR471-R495)

<details>
<summary>
Old (outdated) description
</summary>

## Summary

Fixes false positives when scanning files with very long lines, especially minified JavaScript. This is relevant in contexts where Earlybird is used to scan every branch of a repository, including an orphaned `gh-pages` branch intended to house build artifacts for serving with GitHub Pages.

Whitespaces changes on the modified files are from my editor's interpretation of this project's formatting configuration.

## Problem

The scanner splits lines longer than WorkLength into smaller synthetic chunks before applying content rules. That behavior introduced two issues:

1. False-positive rules marked `UseFullLine: true` were evaluating the chunked fragment rather than the original source line.
2. The overlap helper for long-line splitting was broken and did not actually preserve the previous chunk’s trailing context, so chunks were scanned with even less surrounding context than intended.

On minified files, that meant detections were often evaluated against incomplete, artificial substrings instead of the real line, which caused valid full-line suppressions to stop working and increased false positives.

### Root Cause

- `splitJob` / `splitSubN` rewrote oversized lines into synthetic scan jobs.
- `scanLine` propagated the fragment into hit/postprocess evaluation as if it were the true line.
- `findFalsePositive` and related postprocessing logic used that fragment for UseFullLine checks.
- `splitSubN` dropped the prior chunk tail due to incorrect overlap handling, so the “overlap” path did not preserve boundary context correctly.

## Fix

- Preserve the original unsplit line as internal scan context while still scanning chunked segments.
- Use that original full line for false-positive checks and line-based postprocessing/labeling logic that depends on full context.
- Correct the overlap generation so adjacent long-line chunks produce a real bridge window across the chunk boundary.
- Keep the external report format unchanged. The extra full-line context is internal only.

### Tests

Added regression coverage for:

- Long-line overlap generation.
- False-positive evaluation using the original full line rather than a chunk fragment.

Verified with:

```go
go test ./...
```

</details>