### PR TITLE
fix: overlapping

### DIFF
--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -434,7 +434,7 @@ func splitSubN(s string, n int) []string {
 		// parse from the start of the string
 		toggle = true
 		if len(sub) > overlapLength {
-			tmpString = tmpString + sub[0:overlapLength-1]
+			tmpString = tmpString + sub[0:overlapLength]
 			results = append(results, tmpString) //Append overlapped data
 			results = append(results, sub)       // Append split string
 			tmpString = ""

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -408,41 +408,27 @@ func splitJob(inJob WorkJob, worklength int) (work []WorkJob) {
 // splitSubN Create the overlap string when splitting long strings
 func splitSubN(s string, n int) []string {
 	runes := []rune(s)
-	chunks := make([]string, 0, len(runes)/n)
-	for start := 0; start < len(runes); start += n {
-		if end := start + n; end < len(runes) {
-			chunks = append(chunks, string(runes[start:end]))
-		} else {
-			chunks = append(chunks, string(runes[start:]))
-		}
+	if len(runes) <= n {
+		return []string{s}
+	}
+	results := make([]string, 0, len(runes)/n)
+
+	// Append first chunk before the loop
+	results = append(results, string(runes[0:n]))
+
+	prev := runes[0:n]
+	start := n
+	for ; start+n < len(runes); start += n {
+		cur := runes[start : start+n]
+		bridge := string(prev[n-overlapLength:]) + string(cur[:overlapLength])
+		results = append(results, string(cur))
+		results = append(results, bridge)
+		prev = cur
 	}
 
-	results := make([]string, 0, len(chunks)*2)
-	//subs contains all split strings
-	//iterate over strings parsing
-	toggle := true
-	var tmpString string
-	for _, sub := range chunks {
-		if toggle { // Check if we should parse from the end of the string
-			toggle = false
-			results = append(results, sub) // Append split string
-			if len(sub) >= overlapLength {
-				tmpString = sub[len(sub)-overlapLength:]
-			}
-			continue
-		}
-		// parse from the start of the string
-		toggle = true
-		if len(sub) > overlapLength {
-			tmpString = tmpString + sub[0:overlapLength]
-			results = append(results, tmpString) //Append overlapped data
-			results = append(results, sub)       // Append split string
-			tmpString = ""
-		} else {
-			results = append(results, tmpString+sub) // Append split string
-			break                                    //stop if last element is too short
-		}
-	}
+	// Handle the final tail chunk. Just simply append the bridge to it.
+	last := runes[start:]
+	results = append(results, string(prev[n-overlapLength:])+string(last))
 	return results
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -420,9 +420,11 @@ func splitSubN(s string, n int) []string {
 	start := n
 	for ; start+n < len(runes); start += n {
 		cur := runes[start : start+n]
-		bridge := string(prev[n-overlapLength:]) + string(cur[:overlapLength])
+		if n > overlapLength {
+			bridge := string(prev[n-overlapLength:]) + string(cur[:overlapLength])
+			results = append(results, bridge)
+		}
 		results = append(results, string(cur))
-		results = append(results, bridge)
 		prev = cur
 	}
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -439,9 +439,14 @@ func splitSubN(s string, n int) []string {
 		prev = cur
 	}
 
-	// Handle the final tail chunk. Just simply append the bridge to it.
+	// Handle the final tail chunk. Append bridge and last chunk separately.
 	last := runes[start:]
-	results = append(results, string(prev[n-overlapLength:])+string(last))
+	if len(last) > overlapLength {
+		results = append(results, string(prev[n-overlapLength:]) + string(last[:overlapLength]))
+		results = append(results, string(last))
+	} else{
+		results = append(results, string(prev[n-overlapLength:]) + string(last))
+	}
 	return results
 }
 

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -417,23 +417,17 @@ func splitSubN(s string, n int) []string {
 		}
 	}
 
-	results := []string{}
+	results := make([]string, 0, len(chunks)*2)
 	//subs contains all split strings
 	//iterate over strings parsing
 	toggle := true
+	var tmpString string
 	for _, sub := range chunks {
-		var tmpString string
 		if toggle { // Check if we should parse from the end of the string
 			toggle = false
 			results = append(results, sub) // Append split string
 			if len(sub) >= overlapLength {
 				tmpString = sub[len(sub)-overlapLength:]
-			} else {
-				if len(sub) > 0 {
-					tmpString = sub[len(sub)-(len(sub)-1):]
-				} else {
-					tmpString = sub[0:]
-				}
 			}
 			continue
 		}
@@ -445,8 +439,8 @@ func splitSubN(s string, n int) []string {
 			results = append(results, sub)       // Append split string
 			tmpString = ""
 		} else {
-			results = append(results, sub) // Append split string
-			break                          //stop if last element is too short
+			results = append(results, tmpString+sub) // Append split string
+			break                                    //stop if last element is too short
 		}
 	}
 	return results

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -411,7 +411,20 @@ func splitSubN(s string, n int) []string {
 	if len(runes) <= n {
 		return []string{s}
 	}
-	results := make([]string, 0, len(runes)/n)
+
+	if n <= overlapLength {
+		// simple split only, no bridge
+		results := make([]string, 0, (len(runes) / n))
+		for start := 0; start < len(runes); start += n {
+			end := start + n
+			if end > len(runes) {
+				end = len(runes)
+			}
+			results = append(results, string(runes[start:end]))
+		}
+		return results
+	}
+	results := make([]string, 0, 2*(len(runes)/n))
 
 	// Append first chunk before the loop
 	results = append(results, string(runes[0:n]))
@@ -420,10 +433,8 @@ func splitSubN(s string, n int) []string {
 	start := n
 	for ; start+n < len(runes); start += n {
 		cur := runes[start : start+n]
-		if n > overlapLength {
-			bridge := string(prev[n-overlapLength:]) + string(cur[:overlapLength])
-			results = append(results, bridge)
-		}
+		bridge := string(prev[n-overlapLength:]) + string(cur[:overlapLength])
+		results = append(results, bridge)
 		results = append(results, string(cur))
 		prev = cur
 	}

--- a/pkg/scan/scan_test.go
+++ b/pkg/scan/scan_test.go
@@ -468,6 +468,31 @@ func Test_splitSubN(t *testing.T) {
 			},
 			want: []string{"foo", "bar"},
 		},
+		{
+			name: "Split with overlap bridge",
+			args: args{
+				s: "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGH",
+				n: 30,
+			},
+			want: []string{
+				"ABCDEFGHIJKLMNOPQRSTUVWXYZABCD",
+				"FGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABC",
+				"EFGHIJKLMNOPQRSTUVWXYZABCDEFGH",
+			},
+		},
+		{
+			name: "Split builds overlap for every adjacent pair",
+			args: args{
+				s: "aaaaaxxSECRETyyzzzzz",
+				n: 5,
+			},
+			want: []string{
+				"aaaaa",
+				"xxSEC",
+				"RETyy",
+				"zzzzz",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Issues

- As  correctly pointed out by @BearAlliance "In practice the 'bridge' was not equivalent to prevTail + curHead, it effectively dropped the previous tail." Toggle is adding the overlapping bridge alternately. 
- Initialising tmpString inside the loop does not preserves its value across iterations, instead loosing its value with iteration. 
- Few redundant if conditions were there. 
- Few cases we are slicing a string by byte positions, this can break non ascii character words containing char like ñ or emoji. The code only works reliably with text is made of simple one-byte characters, like plain English letters, digits, and punctuation.
```
s := "añ🌍"
len(s)          // 8  (a=1, ñ=2, 🌍=4 bytes)
len([]rune(s))  // 3  (3 characters)

```


### Improved overlapping logic:
- Adding a consistent bridge overlapping. 
- Preallocating the result slice to its final size, reducing repeated reallocations during each loop iteration.
- Removing redundant if else block and adding a clean simplified logic. 
- Adding the rune in the bridge making also.
- Merging the two loop into just one, reducing the time-complexity from 2n to just simply n, would be useful in case of a big minified file.

### Before
<img width="1263" height="431" alt="Screenshot 2026-05-12 at 1 16 42 PM" src="https://github.com/user-attachments/assets/55d9a0c0-3033-46f2-aca6-46a5c2707544" />  

- Please note that overlapping got corrupt. 


 ### After 
<img width="1390" height="444" alt="Screenshot 2026-05-12 at 1 17 17 PM" src="https://github.com/user-attachments/assets/37f8a36b-f587-43d5-b4a4-9f67e1ae3787" />

