### PR TITLE
fix: semantic release

### DIFF
--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -1,0 +1,56 @@
+name: Changelog PR
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_changelog:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build changelog entry
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_DATE: ${{ github.event.release.published_at }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          # Normalize markdown heading and prepend the latest release at the top.
+          release_date="$(date -u -d "$RELEASE_DATE" +%Y-%m-%d 2>/dev/null || date -u +%Y-%m-%d)"
+          {
+            echo "## [$RELEASE_TAG]($RELEASE_URL) - $release_date"
+            echo
+            printf '%s\n' "$RELEASE_BODY"
+            echo
+          } > /tmp/changelog-entry.md
+
+          if [ -f CHANGELOG.md ]; then
+            cat CHANGELOG.md >> /tmp/changelog-entry.md
+          fi
+
+          mv /tmp/changelog-entry.md CHANGELOG.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs(changelog): update changelog for ${{ github.event.release.tag_name }}"
+          title: "docs(changelog): update changelog for ${{ github.event.release.tag_name }}"
+          body: |
+            Automated changelog update for release `${{ github.event.release.tag_name }}`.
+
+            This PR was created by the `changelog-pr` workflow after publishing a GitHub release.
+          branch: automation/changelog-${{ github.event.release.tag_name }}
+          delete-branch: true
+          labels: |
+            documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get version for next release
         id: getversion
         run: |
-          echo "earlybird_next_version=$(npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release@19.0.2 semantic-release --no-ci --dry-run | grep -o 'The next release version is .*' | awk '{print $NF}')" >> $GITHUB_OUTPUT
+          echo "earlybird_next_version=$(npx -p @semantic-release/github -p @semantic-release/release-notes-generator -p semantic-release@19.0.2 semantic-release --no-ci --dry-run | grep -o 'The next release version is .*' | awk '{print $NF}')" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build:
@@ -65,6 +65,6 @@ jobs:
         with:
           node-version: '16'
       - name: Create a release with Semantic Release
-        run: npx -p @semantic-release/changelog -p @semantic-release/git -p semantic-release@19.0.2 semantic-release
+        run: npx -p @semantic-release/github -p @semantic-release/release-notes-generator -p semantic-release@19.0.2 semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,18 +7,6 @@
       "assets": ["go-earlybird-linux", "go-earlybird-macos", "go-earlybird.exe", "go-earlybird-arm64-macos"],
       "proxy": false
     }],
-    "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"]
-      }
-    ]
+    "@semantic-release/release-notes-generator"
   ]  
 }


### PR DESCRIPTION
## Description

- PR-based changelog flow: Now we update semantic-release config to stop direct pushes, added a new workflow that writes chnagelog and would opens a PR to main instead of directly pushing the changes to main, this change is added to accommodate the repository branch protection rule which will not allow any change in main without PR. [Rules link](https://github.com/americanexpress/earlybird/rules?ref=refs%2Fheads%2Fmain)

## Issue
causing symatic-release workflow job failure. [link](https://github.com/americanexpress/earlybird/actions/runs/25435771661/job/74756679913)