### PR TITLE
fix: peer dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v6
         with:
-          node-version: '16'
+          node-version: '22'
       - name: Get version for next release
         id: getversion
         run: |
-          echo "earlybird_next_version=$(npx -p @semantic-release/github -p @semantic-release/release-notes-generator -p semantic-release@19.0.2 semantic-release --no-ci --dry-run | grep -o 'The next release version is .*' | awk '{print $NF}')" >> $GITHUB_OUTPUT
+          echo "earlybird_next_version=$(npx -p semantic-release -p @semantic-release/github -p @semantic-release/release-notes-generator semantic-release --no-ci --dry-run | grep -o 'The next release version is .*' | awk '{print $NF}')" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build:
@@ -63,8 +63,8 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '16'
+          node-version: '22'
       - name: Create a release with Semantic Release
-        run: npx -p @semantic-release/github -p @semantic-release/release-notes-generator -p semantic-release@19.0.2 semantic-release
+        run: npx -p semantic-release -p @semantic-release/github -p @semantic-release/release-notes-generator semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Issue

The problem is a peer dependency version mismatch, npm resolved @semantic-release/github@12.0.8 which requires semantic-release>=24.1.0, but the workflow pins semantic-release@19.0.2.

## Fix
* Node runtime upgraded from 16 to 22 in both semantic-release jobs.
* npx commands changed to install latest packages for semantic-release.

Workflow run [url](https://github.com/americanexpress/earlybird/actions/runs/26076648248/job/76669117560)